### PR TITLE
ecflow updates

### DIFF
--- a/ecf/def/wafs.def
+++ b/ecf/def/wafs.def
@@ -11,7 +11,7 @@ suite wafs_suite
     family 00
       edit CYC '00'
       task jwafs_gfs_manager
-        trigger  /00/gfs/jgfs_forecast == started  # TODO: Correct the path and Need to ask NCO if this is correct?
+        trigger  /00/gfs/jgfs_forecast == active or /00/gfs/jgfs_forecast == complete
         event 1 release_wafs_upp_anl
         event 2 release_wafs_upp_000
         event 3 release_wafs_upp_001

--- a/ecf/def/wafs.def
+++ b/ecf/def/wafs.def
@@ -259,260 +259,262 @@ suite wafs_suite
           edit FHR 072
       endfamily  # endfamily grib
       family grib2
-        task jwafs_grib2_f006
-          trigger ../upp/jwafs_upp_f006 == complete
-          edit FHR 006
-        task jwafs_grib2_f009
-          trigger ../upp/jwafs_upp_f009 == complete
-          edit FHR 009
-        task jwafs_grib2_f012
-          trigger ../upp/jwafs_upp_f012 == complete
-          edit FHR 012
-        task jwafs_grib2_f015
-          trigger ../upp/jwafs_upp_f015 == complete
-          edit FHR 015
-        task jwafs_grib2_f018
-          trigger ../upp/jwafs_upp_f018 == complete
-          edit FHR 018
-        task jwafs_grib2_f021
-          trigger ../upp/jwafs_upp_f021 == complete
-          edit FHR 021
-        task jwafs_grib2_f024
-          trigger ../upp/jwafs_upp_f024 == complete
-          edit FHR 024
-        task jwafs_grib2_f027
-          trigger ../upp/jwafs_upp_f027 == complete
-          edit FHR 027
-        task jwafs_grib2_f030
-          trigger ../upp/jwafs_upp_f030 == complete
-          edit FHR 030
-        task jwafs_grib2_f033
-          trigger ../upp/jwafs_upp_f033 == complete
-          edit FHR 033
-        task jwafs_grib2_f036
-          trigger ../upp/jwafs_upp_f036 == complete
-          edit FHR 036
-        task jwafs_grib2_f042
-          trigger ../upp/jwafs_upp_f042 == complete
-          edit FHR 042
-        task jwafs_grib2_f048
-          trigger ../upp/jwafs_upp_f048 == complete
-          edit FHR 048
-        task jwafs_grib2_f054
-          trigger ../upp/jwafs_upp_f054 == complete
-          edit FHR 054
-        task jwafs_grib2_f060
-          trigger ../upp/jwafs_upp_f060 == complete
-          edit FHR 060
-        task jwafs_grib2_f066
-          trigger ../upp/jwafs_upp_f066 == complete
-          edit FHR 066
-        task jwafs_grib2_f072
-          trigger ../upp/jwafs_upp_f072 == complete
-          edit FHR 072
+        family 1p25
+          task jwafs_grib2_1p25_f006
+            trigger ../../upp/jwafs_upp_f006 == complete
+            edit FHR 006
+          task jwafs_grib2_1p25_f009
+            trigger ../../upp/jwafs_upp_f009 == complete
+            edit FHR 009
+          task jwafs_grib2_1p25_f012
+            trigger ../../upp/jwafs_upp_f012 == complete
+            edit FHR 012
+          task jwafs_grib2_1p25_f015
+            trigger ../../upp/jwafs_upp_f015 == complete
+            edit FHR 015
+          task jwafs_grib2_1p25_f018
+            trigger ../../upp/jwafs_upp_f018 == complete
+            edit FHR 018
+          task jwafs_grib2_1p25_f021
+            trigger ../../upp/jwafs_upp_f021 == complete
+            edit FHR 021
+          task jwafs_grib2_1p25_f024
+            trigger ../../upp/jwafs_upp_f024 == complete
+            edit FHR 024
+          task jwafs_grib2_1p25_f027
+            trigger ../../upp/jwafs_upp_f027 == complete
+            edit FHR 027
+          task jwafs_grib2_1p25_f030
+            trigger ../../upp/jwafs_upp_f030 == complete
+            edit FHR 030
+          task jwafs_grib2_1p25_f033
+            trigger ../../upp/jwafs_upp_f033 == complete
+            edit FHR 033
+          task jwafs_grib2_1p25_f036
+            trigger ../../upp/jwafs_upp_f036 == complete
+            edit FHR 036
+          task jwafs_grib2_1p25_f042
+            trigger ../../upp/jwafs_upp_f042 == complete
+            edit FHR 042
+          task jwafs_grib2_1p25_f048
+            trigger ../../upp/jwafs_upp_f048 == complete
+            edit FHR 048
+          task jwafs_grib2_1p25_f054
+            trigger ../../upp/jwafs_upp_f054 == complete
+            edit FHR 054
+          task jwafs_grib2_1p25_f060
+            trigger ../../upp/jwafs_upp_f060 == complete
+            edit FHR 060
+          task jwafs_grib2_1p25_f066
+            trigger ../../upp/jwafs_upp_f066 == complete
+            edit FHR 066
+          task jwafs_grib2_1p25_f072
+            trigger ../../upp/jwafs_upp_f072 == complete
+            edit FHR 072
+        endfamily  # endfamily 1p25
+        family 0p25
+          task jwafs_grib2_0p25_f006
+            trigger ../../upp/jwafs_upp_f006 == complete
+            edit FHR 006
+          task jwafs_grib2_0p25_f007
+            trigger ../../upp/jwafs_upp_f007 == complete
+            edit FHR 007
+          task jwafs_grib2_0p25_f008
+            trigger ../../upp/jwafs_upp_f008 == complete
+            edit FHR 008
+          task jwafs_grib2_0p25_f009
+            trigger ../../upp/jwafs_upp_f009 == complete
+            edit FHR 009
+          task jwafs_grib2_0p25_f010
+            trigger ../../upp/jwafs_upp_f010 == complete
+            edit FHR 010
+          task jwafs_grib2_0p25_f011
+            trigger ../../upp/jwafs_upp_f011 == complete
+            edit FHR 011
+          task jwafs_grib2_0p25_f012
+            trigger ../../upp/jwafs_upp_f012 == complete
+            edit FHR 012
+          task jwafs_grib2_0p25_f013
+            trigger ../../upp/jwafs_upp_f013 == complete
+            edit FHR 013
+          task jwafs_grib2_0p25_f014
+            trigger ../../upp/jwafs_upp_f014 == complete
+            edit FHR 014
+          task jwafs_grib2_0p25_f015
+            trigger ../../upp/jwafs_upp_f015 == complete
+            edit FHR 015
+          task jwafs_grib2_0p25_f016
+            trigger ../../upp/jwafs_upp_f016 == complete
+            edit FHR 016
+          task jwafs_grib2_0p25_f017
+            trigger ../../upp/jwafs_upp_f017 == complete
+            edit FHR 017
+          task jwafs_grib2_0p25_f018
+            trigger ../../upp/jwafs_upp_f018 == complete
+            edit FHR 018
+          task jwafs_grib2_0p25_f019
+            trigger ../../upp/jwafs_upp_f019 == complete
+            edit FHR 019
+          task jwafs_grib2_0p25_f020
+            trigger ../../upp/jwafs_upp_f020 == complete
+            edit FHR 020
+          task jwafs_grib2_0p25_f021
+            trigger ../../upp/jwafs_upp_f021 == complete
+            edit FHR 021
+          task jwafs_grib2_0p25_f022
+            trigger ../../upp/jwafs_upp_f022 == complete
+            edit FHR 022
+          task jwafs_grib2_0p25_f023
+            trigger ../../upp/jwafs_upp_f023 == complete
+            edit FHR 023
+          task jwafs_grib2_0p25_f024
+            trigger ../../upp/jwafs_upp_f024 == complete
+            edit FHR 024
+          task jwafs_grib2_0p25_f027
+            trigger ../../upp/jwafs_upp_f027 == complete
+            edit FHR 027
+          task jwafs_grib2_0p25_f030
+            trigger ../../upp/jwafs_upp_f030 == complete
+            edit FHR 030
+          task jwafs_grib2_0p25_f033
+            trigger ../../upp/jwafs_upp_f033 == complete
+            edit FHR 033
+          task jwafs_grib2_0p25_f036
+            trigger ../../upp/jwafs_upp_f036 == complete
+            edit FHR 036
+          task jwafs_grib2_0p25_f039
+            trigger ../../upp/jwafs_upp_f039 == complete
+            edit FHR 039
+          task jwafs_grib2_0p25_f042
+            trigger ../../upp/jwafs_upp_f042 == complete
+            edit FHR 042
+          task jwafs_grib2_0p25_f045
+            trigger ../../upp/jwafs_upp_f045 == complete
+            edit FHR 045
+          task jwafs_grib2_0p25_f048
+            trigger ../../upp/jwafs_upp_f048 == complete
+            edit FHR 048
+          task jwafs_grib2_0p25_f054
+            trigger ../../upp/jwafs_upp_f054 == complete
+            edit FHR 054
+          task jwafs_grib2_0p25_f060
+            trigger ../../upp/jwafs_upp_f060 == complete
+            edit FHR 060
+          task jwafs_grib2_0p25_f066
+            trigger ../../upp/jwafs_upp_f066 == complete
+            edit FHR 066
+          task jwafs_grib2_0p25_f072
+            trigger ../../upp/jwafs_upp_f072 == complete
+            edit FHR 072
+          task jwafs_grib2_0p25_f078
+            trigger ../../upp/jwafs_upp_f078 == complete
+            edit FHR 078
+          task jwafs_grib2_0p25_f084
+            trigger ../../upp/jwafs_upp_f084 == complete
+            edit FHR 084
+          task jwafs_grib2_0p25_f090
+            trigger ../../upp/jwafs_upp_f090 == complete
+            edit FHR 090
+          task jwafs_grib2_0p25_f096
+            trigger ../../upp/jwafs_upp_f096 == complete
+            edit FHR 096
+          task jwafs_grib2_0p25_f102
+            trigger ../../upp/jwafs_upp_f102 == complete
+            edit FHR 102
+          task jwafs_grib2_0p25_f108
+            trigger ../../upp/jwafs_upp_f108 == complete
+            edit FHR 108
+          task jwafs_grib2_0p25_f114
+            trigger ../../upp/jwafs_upp_f114 == complete
+            edit FHR 114
+          task jwafs_grib2_0p25_f120
+            trigger ../../upp/jwafs_upp_f120 == complete
+            edit FHR 120
+        endfamily  # endfamily 0p25
+        family blending
+          task jwafs_grib2_0p25_blending_f006
+            trigger ../jwafs_grib2_0p25_f006 == complete
+            edit FHR 006
+          task jwafs_grib2_0p25_blending_f007
+            trigger ../jwafs_grib2_0p25_f007 == complete
+            edit FHR 007
+          task jwafs_grib2_0p25_blending_f008
+            trigger ../jwafs_grib2_0p25_f008 == complete
+            edit FHR 008
+          task jwafs_grib2_0p25_blending_f009
+            trigger ../jwafs_grib2_0p25_f009 == complete
+            edit FHR 009
+          task jwafs_grib2_0p25_blending_f010
+            trigger ../jwafs_grib2_0p25_f010 == complete
+            edit FHR 010
+          task jwafs_grib2_0p25_blending_f011
+            trigger ../jwafs_grib2_0p25_f011 == complete
+            edit FHR 011
+          task jwafs_grib2_0p25_blending_f012
+            trigger ../jwafs_grib2_0p25_f012 == complete
+            edit FHR 012
+          task jwafs_grib2_0p25_blending_f013
+            trigger ../jwafs_grib2_0p25_f013 == complete
+            edit FHR 013
+          task jwafs_grib2_0p25_blending_f014
+            trigger ../jwafs_grib2_0p25_f014 == complete
+            edit FHR 014
+          task jwafs_grib2_0p25_blending_f015
+            trigger ../jwafs_grib2_0p25_f015 == complete
+            edit FHR 015
+          task jwafs_grib2_0p25_blending_f016
+            trigger ../jwafs_grib2_0p25_f016 == complete
+            edit FHR 016
+          task jwafs_grib2_0p25_blending_f017
+            trigger ../jwafs_grib2_0p25_f017 == complete
+            edit FHR 017
+          task jwafs_grib2_0p25_blending_f018
+            trigger ../jwafs_grib2_0p25_f018 == complete
+            edit FHR 018
+          task jwafs_grib2_0p25_blending_f019
+            trigger ../jwafs_grib2_0p25_f019 == complete
+            edit FHR 019
+          task jwafs_grib2_0p25_blending_f020
+            trigger ../jwafs_grib2_0p25_f020 == complete
+            edit FHR 020
+          task jwafs_grib2_0p25_blending_f021
+            trigger ../jwafs_grib2_0p25_f021 == complete
+            edit FHR 021
+          task jwafs_grib2_0p25_blending_f022
+            trigger ../jwafs_grib2_0p25_f022 == complete
+            edit FHR 022
+          task jwafs_grib2_0p25_blending_f023
+            trigger ../jwafs_grib2_0p25_f023 == complete
+            edit FHR 023
+          task jwafs_grib2_0p25_blending_f024
+            trigger ../jwafs_grib2_0p25_f024 == complete
+            edit FHR 024
+          task jwafs_grib2_0p25_blending_f027
+            trigger ../jwafs_grib2_0p25_f027 == complete
+            edit FHR 027
+          task jwafs_grib2_0p25_blending_f030
+            trigger ../jwafs_grib2_0p25_f030 == complete
+            edit FHR 030
+          task jwafs_grib2_0p25_blending_f033
+            trigger ../jwafs_grib2_0p25_f033 == complete
+            edit FHR 033
+          task jwafs_grib2_0p25_blending_f036
+            trigger ../jwafs_grib2_0p25_f036 == complete
+            edit FHR 036
+          task jwafs_grib2_0p25_blending_f039
+            trigger ../jwafs_grib2_0p25_f039 == complete
+            edit FHR 039
+          task jwafs_grib2_0p25_blending_f042
+            trigger ../jwafs_grib2_0p25_f042 == complete
+            edit FHR 042
+          task jwafs_grib2_0p25_blending_f045
+            trigger ../jwafs_grib2_0p25_f045 == complete
+            edit FHR 045
+          task jwafs_grib2_0p25_blending_f048
+            trigger ../jwafs_grib2_0p25_f048 == complete
+            edit FHR 048
+        endfamily  # endfamily blending
       endfamily  # endfamily grib2
-      family grib2_0p25
-        task jwafs_grib2_0p25_f006
-          trigger ../upp/jwafs_upp_f006 == complete
-          edit FHR 006
-        task jwafs_grib2_0p25_f007
-          trigger ../upp/jwafs_upp_f007 == complete
-          edit FHR 007
-        task jwafs_grib2_0p25_f008
-          trigger ../upp/jwafs_upp_f008 == complete
-          edit FHR 008
-        task jwafs_grib2_0p25_f009
-          trigger ../upp/jwafs_upp_f009 == complete
-          edit FHR 009
-        task jwafs_grib2_0p25_f010
-          trigger ../upp/jwafs_upp_f010 == complete
-          edit FHR 010
-        task jwafs_grib2_0p25_f011
-          trigger ../upp/jwafs_upp_f011 == complete
-          edit FHR 011
-        task jwafs_grib2_0p25_f012
-          trigger ../upp/jwafs_upp_f012 == complete
-          edit FHR 012
-        task jwafs_grib2_0p25_f013
-          trigger ../upp/jwafs_upp_f013 == complete
-          edit FHR 013
-        task jwafs_grib2_0p25_f014
-          trigger ../upp/jwafs_upp_f014 == complete
-          edit FHR 014
-        task jwafs_grib2_0p25_f015
-          trigger ../upp/jwafs_upp_f015 == complete
-          edit FHR 015
-        task jwafs_grib2_0p25_f016
-          trigger ../upp/jwafs_upp_f016 == complete
-          edit FHR 016
-        task jwafs_grib2_0p25_f017
-          trigger ../upp/jwafs_upp_f017 == complete
-          edit FHR 017
-        task jwafs_grib2_0p25_f018
-          trigger ../upp/jwafs_upp_f018 == complete
-          edit FHR 018
-        task jwafs_grib2_0p25_f019
-          trigger ../upp/jwafs_upp_f019 == complete
-          edit FHR 019
-        task jwafs_grib2_0p25_f020
-          trigger ../upp/jwafs_upp_f020 == complete
-          edit FHR 020
-        task jwafs_grib2_0p25_f021
-          trigger ../upp/jwafs_upp_f021 == complete
-          edit FHR 021
-        task jwafs_grib2_0p25_f022
-          trigger ../upp/jwafs_upp_f022 == complete
-          edit FHR 022
-        task jwafs_grib2_0p25_f023
-          trigger ../upp/jwafs_upp_f023 == complete
-          edit FHR 023
-        task jwafs_grib2_0p25_f024
-          trigger ../upp/jwafs_upp_f024 == complete
-          edit FHR 024
-        task jwafs_grib2_0p25_f027
-          trigger ../upp/jwafs_upp_f027 == complete
-          edit FHR 027
-        task jwafs_grib2_0p25_f030
-          trigger ../upp/jwafs_upp_f030 == complete
-          edit FHR 030
-        task jwafs_grib2_0p25_f033
-          trigger ../upp/jwafs_upp_f033 == complete
-          edit FHR 033
-        task jwafs_grib2_0p25_f036
-          trigger ../upp/jwafs_upp_f036 == complete
-          edit FHR 036
-        task jwafs_grib2_0p25_f039
-          trigger ../upp/jwafs_upp_f039 == complete
-          edit FHR 039
-        task jwafs_grib2_0p25_f042
-          trigger ../upp/jwafs_upp_f042 == complete
-          edit FHR 042
-        task jwafs_grib2_0p25_f045
-          trigger ../upp/jwafs_upp_f045 == complete
-          edit FHR 045
-        task jwafs_grib2_0p25_f048
-          trigger ../upp/jwafs_upp_f048 == complete
-          edit FHR 048
-        task jwafs_grib2_0p25_f054
-          trigger ../upp/jwafs_upp_f054 == complete
-          edit FHR 054
-        task jwafs_grib2_0p25_f060
-          trigger ../upp/jwafs_upp_f060 == complete
-          edit FHR 060
-        task jwafs_grib2_0p25_f066
-          trigger ../upp/jwafs_upp_f066 == complete
-          edit FHR 066
-        task jwafs_grib2_0p25_f072
-          trigger ../upp/jwafs_upp_f072 == complete
-          edit FHR 072
-        task jwafs_grib2_0p25_f078
-          trigger ../upp/jwafs_upp_f078 == complete
-          edit FHR 078
-        task jwafs_grib2_0p25_f084
-          trigger ../upp/jwafs_upp_f084 == complete
-          edit FHR 084
-        task jwafs_grib2_0p25_f090
-          trigger ../upp/jwafs_upp_f090 == complete
-          edit FHR 090
-        task jwafs_grib2_0p25_f096
-          trigger ../upp/jwafs_upp_f096 == complete
-          edit FHR 096
-        task jwafs_grib2_0p25_f102
-          trigger ../upp/jwafs_upp_f102 == complete
-          edit FHR 102
-        task jwafs_grib2_0p25_f108
-          trigger ../upp/jwafs_upp_f108 == complete
-          edit FHR 108
-        task jwafs_grib2_0p25_f114
-          trigger ../upp/jwafs_upp_f114 == complete
-          edit FHR 114
-        task jwafs_grib2_0p25_f120
-          trigger ../upp/jwafs_upp_f120 == complete
-          edit FHR 120
-      endfamily  # endfamily grib2_0p25
-      family blending_0p25
-        task jwafs_blending_0p25_f006
-          trigger ../grib2_0p25/jwafs_grib2_0p25_f006 == complete
-          edit FHR 006
-        task jwafs_blending_0p25_f007
-          trigger ../grib2_0p25/jwafs_grib2_0p25_f007 == complete
-          edit FHR 007
-        task jwafs_blending_0p25_f008
-          trigger ../grib2_0p25/jwafs_grib2_0p25_f008 == complete
-          edit FHR 008
-        task jwafs_blending_0p25_f009
-          trigger ../grib2_0p25/jwafs_grib2_0p25_f009 == complete
-          edit FHR 009
-        task jwafs_blending_0p25_f010
-          trigger ../grib2_0p25/jwafs_grib2_0p25_f010 == complete
-          edit FHR 010
-        task jwafs_blending_0p25_f011
-          trigger ../grib2_0p25/jwafs_grib2_0p25_f011 == complete
-          edit FHR 011
-        task jwafs_blending_0p25_f012
-          trigger ../grib2_0p25/jwafs_grib2_0p25_f012 == complete
-          edit FHR 012
-        task jwafs_blending_0p25_f013
-          trigger ../grib2_0p25/jwafs_grib2_0p25_f013 == complete
-          edit FHR 013
-        task jwafs_blending_0p25_f014
-          trigger ../grib2_0p25/jwafs_grib2_0p25_f014 == complete
-          edit FHR 014
-        task jwafs_blending_0p25_f015
-          trigger ../grib2_0p25/jwafs_grib2_0p25_f015 == complete
-          edit FHR 015
-        task jwafs_blending_0p25_f016
-          trigger ../grib2_0p25/jwafs_grib2_0p25_f016 == complete
-          edit FHR 016
-        task jwafs_blending_0p25_f017
-          trigger ../grib2_0p25/jwafs_grib2_0p25_f017 == complete
-          edit FHR 017
-        task jwafs_blending_0p25_f018
-          trigger ../grib2_0p25/jwafs_grib2_0p25_f018 == complete
-          edit FHR 018
-        task jwafs_blending_0p25_f019
-          trigger ../grib2_0p25/jwafs_grib2_0p25_f019 == complete
-          edit FHR 019
-        task jwafs_blending_0p25_f020
-          trigger ../grib2_0p25/jwafs_grib2_0p25_f020 == complete
-          edit FHR 020
-        task jwafs_blending_0p25_f021
-          trigger ../grib2_0p25/jwafs_grib2_0p25_f021 == complete
-          edit FHR 021
-        task jwafs_blending_0p25_f022
-          trigger ../grib2_0p25/jwafs_grib2_0p25_f022 == complete
-          edit FHR 022
-        task jwafs_blending_0p25_f023
-          trigger ../grib2_0p25/jwafs_grib2_0p25_f023 == complete
-          edit FHR 023
-        task jwafs_blending_0p25_f024
-          trigger ../grib2_0p25/jwafs_grib2_0p25_f024 == complete
-          edit FHR 024
-        task jwafs_blending_0p25_f027
-          trigger ../grib2_0p25/jwafs_grib2_0p25_f027 == complete
-          edit FHR 027
-        task jwafs_blending_0p25_f030
-          trigger ../grib2_0p25/jwafs_grib2_0p25_f030 == complete
-          edit FHR 030
-        task jwafs_blending_0p25_f033
-          trigger ../grib2_0p25/jwafs_grib2_0p25_f033 == complete
-          edit FHR 033
-        task jwafs_blending_0p25_f036
-          trigger ../grib2_0p25/jwafs_grib2_0p25_f036 == complete
-          edit FHR 036
-        task jwafs_blending_0p25_f039
-          trigger ../grib2_0p25/jwafs_grib2_0p25_f039 == complete
-          edit FHR 039
-        task jwafs_blending_0p25_f042
-          trigger ../grib2_0p25/jwafs_grib2_0p25_f042 == complete
-          edit FHR 042
-        task jwafs_blending_0p25_f045
-          trigger ../grib2_0p25/jwafs_grib2_0p25_f045 == complete
-          edit FHR 045
-        task jwafs_blending_0p25_f048
-          trigger ../grib2_0p25/jwafs_grib2_0p25_f048 == complete
-          edit FHR 048
-      endfamily  # endfamily blending_0p25
     endfamily  # endfamily 00
   endfamily  # endfamily wafs
 endsuite  # endsuite wafs_suite

--- a/ecf/scripts/.gitignore
+++ b/ecf/scripts/.gitignore
@@ -2,7 +2,7 @@
 upp/jwafs_upp_f*.ecf
 upp/jwafs_upp_anl.ecf
 grib2/1p25/jwafs_grib2_1p25_f*.ecf
-grib2/0p25/ncep/jwafs_grib2_0p25_ncep_f*.ecf
+grib2/0p25/jwafs_grib2_0p25_f*.ecf
 grib2/0p25/blending/jwafs_grib2_0p25_blending_f*.ecf
 gcip/jwafs_gcip_f*.ecf
 grib/jwafs_grib_f*.ecf

--- a/ecf/scripts/.gitignore
+++ b/ecf/scripts/.gitignore
@@ -1,8 +1,8 @@
 # Ignore these
 upp/jwafs_upp_f*.ecf
 upp/jwafs_upp_anl.ecf
-grib2/jwafs_grib2_f*.ecf
-grib2_0p25/jwafs_grib2_0p25_f*.ecf
-blending_0p25/jwafs_blending_0p25_f*.ecf
+grib2/1p25/jwafs_grib2_1p25_f*.ecf
+grib2/0p25/ncep/jwafs_grib2_0p25_ncep_f*.ecf
+grib2/0p25/blending/jwafs_grib2_0p25_blending_f*.ecf
 gcip/jwafs_gcip_f*.ecf
 grib/jwafs_grib_f*.ecf

--- a/ecf/scripts/gcip/jwafs_gcip_master.ecf
+++ b/ecf/scripts/gcip/jwafs_gcip_master.ecf
@@ -17,8 +17,7 @@ set -x
 export NET=%NET%
 export RUN=%RUN%
 export cyc=%CYC%
-export cycle=t%CYC%z
-export FHR=%FHR%
+export fhr=%FHR%
 
 ############################################################
 # Load modules

--- a/ecf/scripts/grib/jwafs_grib_master.ecf
+++ b/ecf/scripts/grib/jwafs_grib_master.ecf
@@ -17,8 +17,7 @@ set -x
 export NET=%NET%
 export RUN=%RUN%
 export cyc=%CYC%
-export cycle=t%CYC%z
-export FHR=%FHR%
+export fhr=%FHR%
 
 ############################################################
 # Load modules

--- a/ecf/scripts/grib2/0p25/blending/jwafs_grib2_0p25_blending_master.ecf
+++ b/ecf/scripts/grib2/0p25/blending/jwafs_grib2_0p25_blending_master.ecf
@@ -1,10 +1,10 @@
 #PBS -S /bin/bash
-#PBS -N %RUN%_grib2_0p25_%FHR%_%CYC%
+#PBS -N %RUN%_blending_0p25_%FHR%_%CYC%
 #PBS -j oe
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:30:00
-#PBS -l select=1:mpiprocs=39:ompthreads=1:ncpus=39:mem=200GB
+#PBS -l select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=15GB
 #PBS -l place=vscatter
 #PBS -l debug=true
 
@@ -26,23 +26,20 @@ export FHR=%FHR%
 module load PrgEnv-intel/${PrgEnv_intel_ver}
 module load craype/${craype_ver}
 module load intel/${intel_ver}
-module load cray-pals/${cray_pals_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}
-module load wgrib2/${wgrib2_ver}
-module load cfp/${cfp_ver}
+module load util_shared/${util_shared_ver}
 
 module list
 
 #############################################################
 # WCOSS environment settings
 #############################################################
-export USE_CFP=YES
 
 ############################################################
 # CALL executable job script here
 ############################################################
-${HOMEwafs}/jobs/JWAFS_GRIB2_0P25
+${HOMEwas}/jobs/JWAFS_GRIB2_0P25_BLENDING
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
    ecflow_client --abort

--- a/ecf/scripts/grib2/0p25/blending/jwafs_grib2_0p25_blending_master.ecf
+++ b/ecf/scripts/grib2/0p25/blending/jwafs_grib2_0p25_blending_master.ecf
@@ -17,8 +17,7 @@ set -x
 export NET=%NET%
 export RUN=%RUN%
 export cyc=%CYC%
-export cycle=t%CYC%z
-export FHR=%FHR%
+export fhr=%FHR%
 
 ############################################################
 # Load modules

--- a/ecf/scripts/grib2/0p25/blending/jwafs_grib2_0p25_blending_master.ecf
+++ b/ecf/scripts/grib2/0p25/blending/jwafs_grib2_0p25_blending_master.ecf
@@ -39,7 +39,7 @@ module list
 ############################################################
 # CALL executable job script here
 ############################################################
-${HOMEwas}/jobs/JWAFS_GRIB2_0P25_BLENDING
+${HOMEwafs}/jobs/JWAFS_GRIB2_0P25_BLENDING
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
    ecflow_client --abort

--- a/ecf/scripts/grib2/0p25/blending/jwafs_grib2_0p25_blending_master.ecf
+++ b/ecf/scripts/grib2/0p25/blending/jwafs_grib2_0p25_blending_master.ecf
@@ -1,5 +1,5 @@
 #PBS -S /bin/bash
-#PBS -N %RUN%_blending_0p25_%FHR%_%CYC%
+#PBS -N %RUN%_grib2_0p25_blending_%FHR%_%CYC%
 #PBS -j oe
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%

--- a/ecf/scripts/grib2/0p25/jwafs_grib2_0p25_master.ecf
+++ b/ecf/scripts/grib2/0p25/jwafs_grib2_0p25_master.ecf
@@ -17,8 +17,7 @@ set -x
 export NET=%NET%
 export RUN=%RUN%
 export cyc=%CYC%
-export cycle=t%CYC%z
-export FHR=%FHR%
+export fhr=%FHR%
 
 ############################################################
 # Load modules

--- a/ecf/scripts/grib2/0p25/jwafs_grib2_0p25_master.ecf
+++ b/ecf/scripts/grib2/0p25/jwafs_grib2_0p25_master.ecf
@@ -42,7 +42,7 @@ export USE_CFP=YES
 ############################################################
 # CALL executable job script here
 ############################################################
-${HOMEwafs}/jobs/JWAFS_GRIB2_0P25_NCEP
+${HOMEwafs}/jobs/JWAFS_GRIB2_0P25
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
    ecflow_client --abort

--- a/ecf/scripts/grib2/0p25/ncep/jwafs_grib2_0p25_ncep_master.ecf
+++ b/ecf/scripts/grib2/0p25/ncep/jwafs_grib2_0p25_ncep_master.ecf
@@ -1,10 +1,10 @@
 #PBS -S /bin/bash
-#PBS -N %RUN%_blending_0p25_%FHR%_%CYC%
+#PBS -N %RUN%_grib2_0p25_%FHR%_%CYC%
 #PBS -j oe
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:30:00
-#PBS -l select=1:mpiprocs=1:ompthreads=1:ncpus=1:mem=15GB
+#PBS -l select=1:mpiprocs=39:ompthreads=1:ncpus=39:mem=200GB
 #PBS -l place=vscatter
 #PBS -l debug=true
 
@@ -26,20 +26,23 @@ export FHR=%FHR%
 module load PrgEnv-intel/${PrgEnv_intel_ver}
 module load craype/${craype_ver}
 module load intel/${intel_ver}
+module load cray-pals/${cray_pals_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}
-module load util_shared/${util_shared_ver}
+module load wgrib2/${wgrib2_ver}
+module load cfp/${cfp_ver}
 
 module list
 
 #############################################################
 # WCOSS environment settings
 #############################################################
+export USE_CFP=YES
 
 ############################################################
 # CALL executable job script here
 ############################################################
-${HOMEwas}/jobs/JWAFS_BLENDING_0P25
+${HOMEwafs}/jobs/JWAFS_GRIB2_0P25_NCEP
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
    ecflow_client --abort

--- a/ecf/scripts/grib2/1p25/jwafs_grib2_1p25_master.ecf
+++ b/ecf/scripts/grib2/1p25/jwafs_grib2_1p25_master.ecf
@@ -42,7 +42,7 @@ export USE_CFP=YES
 ############################################################
 # CALL executable job script here
 ############################################################
-${HOMEwafs}/jobs/JWAFS_GRIB2
+${HOMEwafs}/jobs/JWAFS_GRIB2_1P25
 if [ $? -ne 0 ]; then
    ecflow_client --msg="***JOB ${ECF_NAME} ERROR RUNNING J-SCRIPT ***"
    ecflow_client --abort

--- a/ecf/scripts/grib2/1p25/jwafs_grib2_1p25_master.ecf
+++ b/ecf/scripts/grib2/1p25/jwafs_grib2_1p25_master.ecf
@@ -1,5 +1,5 @@
 #PBS -S /bin/bash
-#PBS -N %RUN%_grib2_%FHR%_%CYC%
+#PBS -N %RUN%_grib2_1p25_%FHR%_%CYC%
 #PBS -j oe
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%

--- a/ecf/scripts/grib2/1p25/jwafs_grib2_1p25_master.ecf
+++ b/ecf/scripts/grib2/1p25/jwafs_grib2_1p25_master.ecf
@@ -17,8 +17,7 @@ set -x
 export NET=%NET%
 export RUN=%RUN%
 export cyc=%CYC%
-export cycle=t%CYC%z
-export FHR=%FHR%
+export fhr=%FHR%
 
 ############################################################
 # Load modules

--- a/ecf/scripts/upp/jwafs_upp_master.ecf
+++ b/ecf/scripts/upp/jwafs_upp_master.ecf
@@ -17,8 +17,7 @@ set -x
 export NET=%NET%
 export RUN=%RUN%
 export cyc=%CYC%
-export cycle=t%CYC%z
-export FHR=%FHR%
+export fhr=%FHR%
 
 ############################################################
 # Load modules

--- a/ecf/setup_ecf_links.sh
+++ b/ecf/setup_ecf_links.sh
@@ -19,7 +19,7 @@ function link_master_to_fhr() {
     target=${tmpl}_f${fhr3}.ecf
     rm -f ${target}
     case ${clean_only} in
-    "YES" | "yes" | "Y" | "y")
+    "YES")
       continue
       ;;
     *)
@@ -29,52 +29,56 @@ function link_master_to_fhr() {
   done
 }
 
+CLEAN=${1:-${CLEAN:-"NO"}}  # Remove links only; do not create links (YES)
+
 # JWAFS_UPP
 cd "${ECF_DIR}/scripts/upp"
 echo "Linking upp ..."
 # Add a link for analysis
 rm -f jwafs_upp_anl.ecf
-ln -sf jwafs_upp_master.ecf jwafs_upp_anl.ecf
+if [[ "${CLEAN}" != "YES" ]]; then
+  ln -sf jwafs_upp_master.ecf jwafs_upp_anl.ecf
+fi
 seq1=$(seq -s ' ' 0 1 24)   # 000 -> 024; 1-hourly
 seq2=$(seq -s ' ' 27 3 48)  # 027 -> 048; 3-hourly
 seq3=$(seq -s ' ' 54 6 120) # 054 -> 120; 6-hourly
 fhrs="${seq1} ${seq2} ${seq3}"
-link_master_to_fhr "jwafs_upp" "${fhrs}" "${CLEAN:-}"
+link_master_to_fhr "jwafs_upp" "${fhrs}" "${CLEAN}"
 
 # JWAFS_GRIB2
-cd "${ECF_DIR}/scripts/grib2"
-echo "Linking grib2 ..."
+cd "${ECF_DIR}/scripts/grib2/1p25"
+echo "Linking grib2/1p25 ..."
 seq1="0"                   # 000
 seq2=$(seq -s ' ' 6 3 36)  # 006 -> 036; 3-hourly
 seq3=$(seq -s ' ' 42 6 72) # 042 -> 072; 6-hourly
 fhrs="${seq1} ${seq2} ${seq3}"
-link_master_to_fhr "jwafs_grib2" "${fhrs}" "${CLEAN:-}"
+link_master_to_fhr "jwafs_grib2_1p25" "${fhrs}" "${CLEAN}"
 
 # JWAFS_GRIB2_0P25
-cd "${ECF_DIR}/scripts/grib2_0p25"
-echo "Linking grib2_0p25 ..."
+cd "${ECF_DIR}/scripts/grib2/0p25/ncep"
+echo "Linking grib2/0p25/ncep ..."
 seq1=$(seq -s ' ' 6 1 24)   # 006 -> 024; 1-hourly
 seq2=$(seq -s ' ' 27 3 48)  # 027 -> 048; 3-hourly
 seq3=$(seq -s ' ' 54 6 120) # 054 -> 120; 6-hourly
 fhrs="${seq1} ${seq2} ${seq3}"
-link_master_to_fhr "jwafs_grib2_0p25" "${fhrs}" "${CLEAN:-}"
+link_master_to_fhr "jwafs_grib2_0p25_ncep" "${fhrs}" "${CLEAN}"
 
 # JWAFS_BLENDING_0P25
-cd "${ECF_DIR}/scripts/blending_0p25"
-echo "Linking blending_0p25 ..."
+cd "${ECF_DIR}/scripts/grib2/0p25/blending"
+echo "Linking grib2/0p25/blending ..."
 seq1=$(seq -s ' ' 6 1 24)  # 006 -> 024; 1-hourly
 seq2=$(seq -s ' ' 27 3 48) # 027 -> 048; 3-hourly
 fhrs="${seq1} ${seq2}"
-link_master_to_fhr "jwafs_blending_0p25" "${fhrs}" "${CLEAN:-}"
+link_master_to_fhr "jwafs_grib2_0p25_blending" "${fhrs}" "${CLEAN}"
 
 # JWAFS_GCIP
 cd "${ECF_DIR}/scripts/gcip"
 echo "Linking gcip ..."
 fhrs="0 3" # 000, 003
-link_master_to_fhr "jwafs_gcip" "${fhrs}" "${CLEAN:-}"
+link_master_to_fhr "jwafs_gcip" "${fhrs}" "${CLEAN}"
 
 # JWAFS_GRIB
 cd "${ECF_DIR}/scripts/grib"
 echo "Linking grib ..."
 fhrs=$(seq -s ' ' 6 6 72) # 006 -> 072; 6-hourly
-link_master_to_fhr "jwafs_grib" "${fhrs}" "${CLEAN:-}"
+link_master_to_fhr "jwafs_grib" "${fhrs}" "${CLEAN}"

--- a/ecf/setup_ecf_links.sh
+++ b/ecf/setup_ecf_links.sh
@@ -55,13 +55,13 @@ fhrs="${seq1} ${seq2} ${seq3}"
 link_master_to_fhr "jwafs_grib2_1p25" "${fhrs}" "${CLEAN}"
 
 # JWAFS_GRIB2_0P25
-cd "${ECF_DIR}/scripts/grib2/0p25/ncep"
-echo "Linking grib2/0p25/ncep ..."
+cd "${ECF_DIR}/scripts/grib2/0p25"
+echo "Linking grib2/0p25 ..."
 seq1=$(seq -s ' ' 6 1 24)   # 006 -> 024; 1-hourly
 seq2=$(seq -s ' ' 27 3 48)  # 027 -> 048; 3-hourly
 seq3=$(seq -s ' ' 54 6 120) # 054 -> 120; 6-hourly
 fhrs="${seq1} ${seq2} ${seq3}"
-link_master_to_fhr "jwafs_grib2_0p25_ncep" "${fhrs}" "${CLEAN}"
+link_master_to_fhr "jwafs_grib2_0p25" "${fhrs}" "${CLEAN}"
 
 # JWAFS_BLENDING_0P25
 cd "${ECF_DIR}/scripts/grib2/0p25/blending"

--- a/jobs/JWAFS_GFS_MANAGER
+++ b/jobs/JWAFS_GFS_MANAGER
@@ -75,16 +75,15 @@ $HOMEwafs/scripts/exwafs_gfs_manager.sh
 ############################################
 # print exec output
 ############################################
-if [ -e "$pgmout" ] ; then
+if [ -e "$pgmout" ]; then
   cat $pgmout
 fi
 
 ############################################
 # remove temporary working directory
 ############################################
-if [ $KEEPDATA != YES ] ; then
-    rm -rf $DATA
+if [ $KEEPDATA != YES ]; then
+  rm -rf $DATA
 fi
 
 date
-

--- a/scripts/exwafs_gfs_manager.sh
+++ b/scripts/exwafs_gfs_manager.sh
@@ -36,7 +36,7 @@ for ((iter = 1; iter <= MAX_ITER; iter++)); do
     fhr3=$(printf "%03d" "${fhr}")
 
     # Trigger jobs based on GFS forecast output availability
-    if [[ -s "${COMINgfs}/gfs.t${cyc}z.logf${fhr3}.txt" ]]; then
+    if [[ -s "${COMINgfs}/gfs.${cycle}.logf${fhr3}.txt" ]]; then
 
       # Release the JWAFS_UPP analysis job if this is f000
       if ((fhr == 0)); then


### PR DESCRIPTION
Following a discussion w/ NCO, this PR addresses their concerns and updates the suite definition and ecflow scripts to EE2 implementation standards.

Specifically, this PR:
- updates the trigger to JWAFS_GFS_MANAGER based on active or completed JGFS_FORECAST job.
- updates the `grib2` products structure
- ecf exports `fhr` as the forecast hour to process and use in the j-jobs
- ecf removes `cycle`.  `cycle` is created in the j-job as `t${cyc}z`.  It should not be exported from ecf.

The `ecflow` scripts structure looks like:
```bash
❯❯❯ tree scripts
scripts
├── gcip
│   └── jwafs_gcip_master.ecf
├── grib
│   └── jwafs_grib_master.ecf
├── grib2
│   ├── 0p25
│   │   ├── blending
│   │   │   └── jwafs_grib2_0p25_blending_master.ecf
│   │   └── jwafs_grib2_0p25_master.ecf
│   └── 1p25
│       └── jwafs_grib2_1p25_master.ecf
├── jwafs_gfs_manager.ecf
└── upp
    └── jwafs_upp_master.ecf
```

@YaliMao-NOAA 
Please make note of the changes in the names of the j-jobs reflecting the ecflow suite structure.