### PR TITLE
Simplify WAFS UPP scripts

### DIFF
--- a/dev/driver/run_JWAFS_UPP.wcoss2
+++ b/dev/driver/run_JWAFS_UPP.wcoss2
@@ -86,18 +86,13 @@ USER=`whoami`
 
 ############################################
 # SENDCOM=YES--Copy output file to /com
-# SENDECF=YES--Allow to talk back to ECF
 # SENDDBN=YES--Alert output file to TOC
 # KEEPDATA=NO--Remove temporary working
 ############################################
 export SENDCOM=YES
 export SENDDBN=NO
-export RERUN=NO
-export VERBOSE=YES
 
 export KEEPDATA=YES
-
-export OUTPUT_FILE=netcdf
 
 ############################################
 # Define DATA, COMOUT and COMIN

--- a/ush/wafs_upp.sh
+++ b/ush/wafs_upp.sh
@@ -10,7 +10,7 @@ export HH=`echo $VDATE | cut -c9-10`
 
 run=`echo $RUNupp | tr '[a-z]' '[A-Z]'`
 cat > itag <<EOF
-$NEMSINP
+$ATMINP
 ${MODEL_OUT_FORM}
 grib2
 ${YY}-${MM}-${DD}_${HH}:00:00


### PR DESCRIPTION
Simplify WAFS UPP script by removing legacy variables, and their unnecessary conditions to run WAFS UPP.
Legacy variables: OUTTYP, OUTPUT_FILE

Also remove stime and use fhr instead