### PR TITLE
Change filenames for UK, add 5 more minutes to the waiting window of UK unblended data

### DIFF
--- a/dev/driver/run_JWAFS_GRIB2_0P25_BLENDING.wcoss2
+++ b/dev/driver/run_JWAFS_GRIB2_0P25_BLENDING.wcoss2
@@ -3,7 +3,7 @@
 #PBS -j oe
 #PBS -o /lfs/h2/emc/ptmp/yali.mao/working_wafs/log.wafs_grib2_0p25_blending
 #PBS -N wafs_blending_0p25
-#PBS -l walltime=00:15:00
+#PBS -l walltime=00:25:00
 #PBS -l select=1:ncpus=1
 #PBS -q debug
 #PBS -l debug=true

--- a/jobs/JWAFS_GRIB2_0P25_BLENDING
+++ b/jobs/JWAFS_GRIB2_0P25_BLENDING
@@ -78,7 +78,8 @@ export COMINuk=${COMINuk:-$DCOMROOT/$PDY/wgrbbul/ukmet_wafs}
 ###############################################
 # export SLEEP_TIME=300   # changed to 60 to avoid hitting wall_clock when miss umket wafs files ... 
 # JY -0129: export SLEEP_TIME=600
-export SLEEP_TIME=600
+# Aug2024: export SLEEP_TIME=1200 (20 minutes, T+4:30 - T+4:50)
+export SLEEP_TIME=1200
 export SLEEP_INT=10
 
 ############################################

--- a/scripts/exwafs_grib2_0p25.sh
+++ b/scripts/exwafs_grib2_0p25.sh
@@ -93,12 +93,12 @@ $WGRIB2 tmp_master.grb2 $opt1 $opt21 ":(UGRD|VGRD):max wind" $opt23 $opt24 -new_
 # Product 1: WAFS u/v/t/rh wafs.tHHz.0p25.fFFF.grib2
 #---------------------------
 $WGRIB2 tmp_wafs_0p25.grb2 | egrep "UGRD|VGRD|TMP|HGT|RH" \
-    | $WGRIB2 -i tmp_wafs_0p25.grb2 -set master_table 25 -grib tmp.${RUN}.t${cyc}z.0p25.f${fhr}.grib2
-cat tmp_master_0p25.grb2 >> tmp.${RUN}.t${cyc}z.0p25.f${fhr}.grib2
+    | $WGRIB2 -i tmp_wafs_0p25.grb2 -set master_table 25 -grib tmp.gfs.t${cyc}z.wafs_0p25.f${fhr}.grib2
+cat tmp_master_0p25.grb2 >> tmp.gfs.t${cyc}z.wafs_0p25.f${fhr}.grib2
 # Convert template 5 to 5.40
-#$WGRIB2 tmp.${RUN}.t${cyc}z.0p25.f${fhr}.grib2 -set_grib_type jpeg -grib_out ${RUN}.t${cyc}z.0p25.f${fhr}.grib2
-mv tmp.${RUN}.t${cyc}z.0p25.f${fhr}.grib2 ${RUN}.t${cyc}z.0p25.f${fhr}.grib2
-$WGRIB2 -s ${RUN}.t${cyc}z.0p25.f${fhr}.grib2 > ${RUN}.t${cyc}z.0p25.f${fhr}.grib2.idx
+#$WGRIB2 tmp.gfs.t${cyc}z.wafs_0p25.f${fhr}.grib2 -set_grib_type jpeg -grib_out gfs.t${cyc}z.wafs_0p25.f${fhr}.grib2
+mv tmp.gfs.t${cyc}z.wafs_0p25.f${fhr}.grib2 gfs.t${cyc}z.wafs_0p25.f${fhr}.grib2
+$WGRIB2 -s gfs.t${cyc}z.wafs_0p25.f${fhr}.grib2 > gfs.t${cyc}z.wafs_0p25.f${fhr}.grib2.idx
 
 if [ $hazard_timewindow = 'yes' ] ; then
 #---------------------------
@@ -118,9 +118,9 @@ if [ $hazard_timewindow = 'yes' ] ; then
 	| $WGRIB2 -i tmp_wafs_0p25.grb2 -set master_table 25 -grib tmp_wafs_0p25.grb2.forblend
 
     # Convert template 5 to 5.40
-    #$WGRIB2 tmp_wafs_0p25.grb2.forblend -set_grib_type jpeg -grib_out ${RUN}.t${cyc}z.unblended.0p25.f${fhr}.grib2
-    mv tmp_wafs_0p25.grb2.forblend ${RUN}.t${cyc}z.unblended.0p25.f${fhr}.grib2
-    $WGRIB2 -s ${RUN}.t${cyc}z.unblended.0p25.f${fhr}.grib2 > ${RUN}.t${cyc}z.unblended.0p25.f${fhr}.grib2.idx
+    #$WGRIB2 tmp_wafs_0p25.grb2.forblend -set_grib_type jpeg -grib_out WAFS_0p25_unblended_$PDY${cyc}f${fhr}.grib2
+    mv tmp_wafs_0p25.grb2.forblend WAFS_0p25_unblended_$PDY${cyc}f${fhr}.grib2
+    $WGRIB2 -s WAFS_0p25_unblended_$PDY${cyc}f${fhr}.grib2 > WAFS_0p25_unblended_$PDY${cyc}f${fhr}.grib2.idx
 fi
 
 if [ $SENDCOM = "YES" ] ; then
@@ -129,15 +129,15 @@ if [ $SENDCOM = "YES" ] ; then
    # Post Files to COM
    ##############################
 
-    cpfs ${RUN}.t${cyc}z.0p25.f${fhr}.grib2 $COMOUT/${RUN}.t${cyc}z.0p25.f${fhr}.grib2
-    cpfs ${RUN}.t${cyc}z.0p25.f${fhr}.grib2.idx $COMOUT/${RUN}.t${cyc}z.0p25.f${fhr}.grib2.idx
+    cpfs gfs.t${cyc}z.wafs_0p25.f${fhr}.grib2 $COMOUT/gfs.t${cyc}z.wafs_0p25.f${fhr}.grib2
+    cpfs gfs.t${cyc}z.wafs_0p25.f${fhr}.grib2.idx $COMOUT/gfs.t${cyc}z.wafs_0p25.f${fhr}.grib2.idx
 
    if [ $hazard_timewindow = 'yes' ] ; then
        cpfs ${RUN}.t${cyc}z.awf.0p25.f${fhr}.grib2 $COMOUT/${RUN}.t${cyc}z.awf.0p25.f${fhr}.grib2
        cpfs ${RUN}.t${cyc}z.awf.0p25.f${fhr}.grib2.idx $COMOUT/${RUN}.t${cyc}z.awf.0p25.f${fhr}.grib2.idx
        
-       cpfs ${RUN}.t${cyc}z.unblended.0p25.f${fhr}.grib2 $COMOUT/${RUN}.t${cyc}z.unblended.0p25.f${fhr}.grib2
-       cpfs ${RUN}.t${cyc}z.unblended.0p25.f${fhr}.grib2.idx $COMOUT/${RUN}.t${cyc}z.unblended.0p25.f${fhr}.grib2.idx
+       cpfs WAFS_0p25_unblended_$PDY${cyc}f${fhr}.grib2 $COMOUT/WAFS_0p25_unblended_$PDY${cyc}f${fhr}.grib2
+       cpfs WAFS_0p25_unblended_$PDY${cyc}f${fhr}.grib2.idx $COMOUT/WAFS_0p25_unblended_$PDY${cyc}f${fhr}.grib2.idx
    fi
 
 fi
@@ -152,11 +152,11 @@ if [ $SENDDBN = "YES" ] ; then
 	$DBNROOT/bin/dbn_alert MODEL WAFS_AWF.0P25_GB2 $job $COMOUT/${RUN}.t${cyc}z.awf.0p25.f${fhr}.grib2
 
 	# Unblended US WAFS data sent to UK for blending, to the same server as 1.25 deg unblended data: wmo/grib2.tCCz.wafs_grb_wifsfFF.45
-	$DBNROOT/bin/dbn_alert MODEL WAFS_0P25_UBL_GB2 $job $COMOUT/${RUN}.t${cyc}z.unblended.0p25.f${fhr}.grib2
+	$DBNROOT/bin/dbn_alert MODEL WAFS_0P25_UBL_GB2 $job $COMOUT/WAFS_0p25_unblended_$PDY${cyc}f${fhr}.grib2
     fi
 
     # WAFS U/V/T/RH data sent to the same server as the unblended data as above
-    $DBNROOT/bin/dbn_alert MODEL WAFS_0P25_GB2 $job $COMOUT/${RUN}.t${cyc}z.0p25.f${fhr}.grib2
+    $DBNROOT/bin/dbn_alert MODEL WAFS_0P25_GB2 $job $COMOUT/gfs.t${cyc}z.wafs_0p25.f${fhr}.grib2
 
 fi
 

--- a/scripts/exwafs_grib2_0p25_blending.sh
+++ b/scripts/exwafs_grib2_0p25_blending.sh
@@ -43,12 +43,12 @@ fhr="$(printf "%03d" $(( 10#$fhr )) )"
 export ic=1
 while [ $ic -le $SLEEP_LOOP_MAX ]
 do 
-    if [ -s ${COMINus}/wafs.t${cyc}z.unblended.0p25.f${fhr}.grib2 ] ; then
+    if [ -s ${COMINus}/WAFS_0p25_unblended_$PDY${cyc}f${fhr}.grib2 ] ; then
         break
     fi
     if [ $ic -eq $SLEEP_LOOP_MAX ] ; then
-        echo "US WAFS GRIB2 file  $COMINus/wafs.t${cyc}z.unblended.0p25.f${fhr}.grib2 not found after waiting over $SLEEP_TIME seconds"
-	echo "US WAFS GRIB2 file " $COMINus/wafs.t${cyc}z.unblended.0p25.f${fhr}.grib2 "not found after waiting ",$SLEEP_TIME, "exitting"
+        echo "US WAFS GRIB2 file  $COMINus/WAFS_0p25_unblended_$PDY${cyc}f${fhr}.grib2 not found after waiting over $SLEEP_TIME seconds"
+	echo "US WAFS GRIB2 file " $COMINus/WAFS_0p25_unblended_$PDY${cyc}f${fhr}.grib2 "not found after waiting ",$SLEEP_TIME, "exitting"
 	SEND_UK_WAFS=YES
 	break
     else
@@ -112,14 +112,14 @@ else # elif [ $SEND_US_WAFS = "NO" -a $SEND_UK_WAFS = "NO" ] ; then
     cat $COMINuk/egrr_wafshzds_unblended_*_0p25_${YYYY}-${MM}-${DD}T${cyc}:00Z_t$fhr.grib2 > EGRR_WAFS_0p25_unblended_${PDY}_${cyc}z_t${fhr}.grib2
     
     # pick up US data
-    cp ${COMINus}/wafs.t${cyc}z.unblended.0p25.f${fhr}.grib2 .
+    cp ${COMINus}/WAFS_0p25_unblended_$PDY${cyc}f${fhr}.grib2 .
 
     # run blending code
     export pgm=wafs_blending_0p25.x
     . prep_step
 
     startmsg
-    $EXECwafs/$pgm wafs.t${cyc}z.unblended.0p25.f${fhr}.grib2 \
+    $EXECwafs/$pgm WAFS_0p25_unblended_$PDY${cyc}f${fhr}.grib2 \
                    EGRR_WAFS_0p25_unblended_${PDY}_${cyc}z_t${fhr}.grib2 \
                    0p25_blended_${PDY}${cyc}f${fhr}.grib2 > f${fhr}.out
 
@@ -171,16 +171,16 @@ if [ $SEND_US_WAFS = "YES" ] ; then
     #
     #   Distribute US WAFS unblend Data to NCEP FTP Server (WOC) and TOC
     #
-    echo "altering the unblended US WAFS products - $COMINus/wafs.t${cyc}z.unblended.0p25.f${fhr}.grib2 "
-    echo "and $COMINus/wafs.t${cyc}z.unblended.0p25.f${fhr}.grib2.idx "
+    echo "altering the unblended US WAFS products - $COMINus/WAFS_0p25_unblended_$PDY${cyc}f${fhr}.grib2 "
+    echo "and $COMINus/WAFS_0p25_unblended_$PDY${cyc}f${fhr}.grib2.idx "
 
     if [ $SENDDBN = "YES" ] ; then
-	$DBNROOT/bin/dbn_alert MODEL WAFS_0P25_UBL_GB2 $job $COMINus/wafs.t${cyc}z.unblended.0p25.f${fhr}.grib2
-	$DBNROOT/bin/dbn_alert MODEL WAFS_0P25_UBL_GB2_WIDX $job $COMINus/wafs.t${cyc}z.unblended.0p25.f${fhr}.grib2.idx
+	$DBNROOT/bin/dbn_alert MODEL WAFS_0P25_UBL_GB2 $job $COMINus/WAFS_0p25_unblended_$PDY${cyc}f${fhr}.grib2
+	$DBNROOT/bin/dbn_alert MODEL WAFS_0P25_UBL_GB2_WIDX $job $COMINus/WAFS_0p25_unblended_$PDY${cyc}f${fhr}.grib2.idx
     fi
 
 #	 if [ $SENDDBN_NTC = "YES" ] ; then
-#	     $DBNROOT/bin/dbn_alert NTC_LOW $NET $job $COMOUT/wafs.t${cyc}z.unblended.0p25.f${fhr}.grib2
+#	     $DBNROOT/bin/dbn_alert NTC_LOW $NET $job $COMOUT/WAFS_0p25_unblended_$PDY${cyc}f${fhr}.grib2
 #	 fi
 
 
@@ -257,7 +257,7 @@ else
     #   Distribute US WAFS unblend Data to NCEP FTP Server (WOC) and TOC
     #
     if [ $SENDCOM = YES ]; then
-	cpfs 0p25_blended_${PDY}${cyc}f${fhr}.grib2 $COMOUT/wafs.t${cyc}z.blended.0p25.f${fhr}.grib2
+	cpfs 0p25_blended_${PDY}${cyc}f${fhr}.grib2 $COMOUT/WAFS_0p25_blended_$PDY${cyc}f$fhr.grib2
 	## cp grib2.t${cyc}z.WAFS_0p25_blended_f${fhr}  $PCOM/grib2.t${cyc}z.WAFS_0p25_blended_f${fhr}
     fi
 
@@ -268,7 +268,7 @@ else
     fi
 
     if [ $SENDDBN = "YES" ] ; then
-	$DBNROOT/bin/dbn_alert MODEL WAFS_0P25_BL_GB2 $job $COMOUT/wafs.t${cyc}z.blended.0p25.f${fhr}.grib2
+	$DBNROOT/bin/dbn_alert MODEL WAFS_0P25_BL_GB2 $job $COMOUT/WAFS_0p25_blended_$PDY${cyc}f$fhr.grib2
     fi 
 fi
 

--- a/scripts/exwafs_grib2_1p25.sh
+++ b/scripts/exwafs_grib2_1p25.sh
@@ -128,14 +128,14 @@ if [ $wafs_timewindow = 'yes' ] ; then
             -set master_table 6 \
             -new_grid_winds earth -set_grib_type jpeg \
             -new_grid_interpolation bilinear -if ":(UGRD|VGRD):max wind" -new_grid_interpolation neighbor -fi \
-            -new_grid latlon 0:288:1.25 90:145:-1.25 ${RUN}.t${cyc}z.grid45.f${fhr}.grib2
-    $WGRIB2 -s ${RUN}.t${cyc}z.grid45.f${fhr}.grib2 > ${RUN}.t${cyc}z.grid45.f${fhr}.grib2.idx
+            -new_grid latlon 0:288:1.25 90:145:-1.25 gfs.t${cyc}z.wafs_grb45f${fhr}.grib2
+    $WGRIB2 -s gfs.t${cyc}z.wafs_grb45f${fhr}.grib2 > gfs.t${cyc}z.wafs_grb45f${fhr}.grib2.idx
 
     # For WAFS, add WMO header. Processing WAFS GRIB2 grid 45 for ISCS and WIFS
     export pgm=$TOCGRIB2
     . prep_step
     startmsg
-    export FORT11=${RUN}.t${cyc}z.grid45.f${fhr}.grib2
+    export FORT11=gfs.t${cyc}z.wafs_grb45f${fhr}.grib2
     export FORT31=" "
     export FORT51=grib2.wafs.t${cyc}z.grid45.f${fhr}
     $TOCGRIB2 < wafs_wmo_header45 >> $pgmout 2> errfile
@@ -156,8 +156,8 @@ if [ $SENDCOM = "YES" ] ; then
 
     # WAFS data
     if [ $wafs_timewindow = 'yes' ] ; then
-	cpfs ${RUN}.t${cyc}z.grid45.f${fhr}.grib2 $COMOUT/${RUN}.t${cyc}z.grid45.f${fhr}.grib2
-	cpfs ${RUN}.t${cyc}z.grid45.f${fhr}.grib2.idx $COMOUT/${RUN}.t${cyc}z.grid45.f${fhr}.grib2.idx
+	cpfs gfs.t${cyc}z.wafs_grb45f${fhr}.grib2 $COMOUT/gfs.t${cyc}z.wafs_grb45f${fhr}.grib2
+	cpfs gfs.t${cyc}z.wafs_grb45f${fhr}.grib2.idx $COMOUT/gfs.t${cyc}z.wafs_grb45f${fhr}.grib2.idx
     fi
 
     ##############################
@@ -181,7 +181,7 @@ if [ $SENDDBN = "YES" ] ; then
 #    Distribute Data to WOC
 #  
     if [ $wafs_timewindow = 'yes' ] ; then
-	$DBNROOT/bin/dbn_alert MODEL WAFS_1P25_GB2 $job $COMOUT/${RUN}.t${cyc}z.grid45.f${fhr}.grib2
+	$DBNROOT/bin/dbn_alert MODEL WAFS_1P25_GB2 $job $COMOUT/gfs.t${cyc}z.wafs_grb45f${fhr}.grib2
 #
 #       Distribute Data to TOC TO WIFS FTP SERVER (AWC)
 #


### PR DESCRIPTION
1. Per request from UK and NCO dataflow, change filenames back to what UK has been always using. This is approved by NCO even though it doesn't follow EE2 standards.
    
 2. Add 5 more minutes to the waiting time of UK unblended data totoal is 20 minutes
