### PR TITLE
add manual for a sample job

### DIFF
--- a/ecf/scripts/jwafs_gfs_manager.ecf
+++ b/ecf/scripts/jwafs_gfs_manager.ecf
@@ -48,4 +48,7 @@ PURPOSE: Look for GFS forecast model output and trigger the following jobs:
 This job will look for GFS forecast model output, and trigger the above jobs for each of the forecast hour that the products are desired.
 The job will timeout in 10800 seconds (3 hours) if the forecast model output is not available.
 The job will skip any intermediate forecast hour if the forecast model output is not available for that forecast hour
+
+TROUBLESHOOTING
+If this job fails, re-queuing the job is probably not the best idea as it may release the triggers for already launched/completed downstream jobs.  In that case, it is perhaps better to boot the downstream jobs mentioned in the purpose for the failed forecast hours.
 %end

--- a/ecf/scripts/jwafs_gfs_manager.ecf
+++ b/ecf/scripts/jwafs_gfs_manager.ecf
@@ -38,4 +38,14 @@ fi
 
 %include <tail.h>
 %manual
+TASK: JWAFS_GFS_MANAGER
+
+PURPOSE: Look for GFS forecast model output and trigger the following jobs:
+  JWAFS_UPP: Offline UPP with GTG
+  JWAFS_GCIP:
+  JWAFS_GRIB:
+
+This job will look for GFS forecast model output, and trigger the above jobs for each of the forecast hour that the products are desired.
+The job will timeout in 10800 seconds (3 hours) if the forecast model output is not available.
+The job will skip any intermediate forecast hour if the forecast model output is not available for that forecast hour
 %end

--- a/scripts/exwafs_grib2_0p25.sh
+++ b/scripts/exwafs_grib2_0p25.sh
@@ -47,7 +47,8 @@ cpreq "${WAFS_MASTER}" ./wafs_master.grib2
 ${WGRIB2} "./wafs_master.grib2" ${opt1} ${opt21} ${opt22} ${opt23} ${opt24} -new_grid ${newgrid} tmp_wafs_0p25.grb2
 # GFS 2D data
 cpreq "${GFS_MASTER}" ./gfs_master.grib2
-${WGRIB2} "./gfs_master.grib2" | grep -F -f "${FIXwafs}/wafs/grib2_0p25_gfs_master2d.list" |
+cpreq "${FIXwafs}/wafs/grib2_0p25_gfs_master2d.list" ./
+${WGRIB2} "./gfs_master.grib2" | grep -F -f "./grib2_0p25_gfs_master2d.list" |
     ${WGRIB2} -i "./gfs_master.grib2" -set master_table 25 -grib tmp_master.grb2
 ${WGRIB2} tmp_master.grb2 ${opt1} ${opt21} ":(UGRD|VGRD):max wind" ${opt23} ${opt24} -new_grid ${newgrid} tmp_master_0p25.grb2
 
@@ -76,7 +77,8 @@ if [[ "${hazard_timewindow}" == "YES" ]]; then
     #---------------------------
     # Product 3: WAFS unblended EDPARM, ICESEV, CB (No CAT MWT) wafs.tHHz.unblended.0p25.fFFF.grib2
     #---------------------------
-    ${WGRIB2} tmp_wafs_0p25.grb2 | grep -F -f "${FIXwafs}/wafs/grib2_0p25_wafs_hazard.list" |
+    cpreq "${FIXwafs}/wafs/grib2_0p25_wafs_hazard.list" ./
+    ${WGRIB2} tmp_wafs_0p25.grb2 | grep -F -f "./grib2_0p25_wafs_hazard.list" |
         ${WGRIB2} -i tmp_wafs_0p25.grb2 -set master_table 25 -grib tmp_wafs_0p25.grb2.forblend
 
     # Convert template 5 to 5.40

--- a/scripts/exwafs_grib2_0p25_blending.sh
+++ b/scripts/exwafs_grib2_0p25_blending.sh
@@ -138,14 +138,15 @@ if [[ "${envir}" != "prod" ]]; then
 fi
 maillist=${maillist:-"nco.spa@noaa.gov,ncep.sos@noaa.gov"}
 
+cpreq "${FIXwafs}/wafs/wafs_blending_0p25_admin_msg" ./
 if [[ "${SEND_US_WAFS}" == "YES" ]]; then
 
     #  checking any US WAFS product was sent due to No UK WAFS GRIB2 file or WAFS blending program
     #  (Alert once for each forecast hour)
     if [[ "${SEND_AWC_US_ALERT}" == "NO" ]]; then
         echo "WARNING: Missing UK data for WAFS GRIB2 0P25 blending. Send alert message to AWC ......"
-        make_NTC_file.pl NOXX10 KKCI "${PDY}${cyc}" NONE "${FIXwafs}/wafs/wafs_blending_0p25_admin_msg" "${COMOUTwmo}/wifs_0p25_admin_msg"
-        make_NTC_file.pl NOXX10 KWBC "${PDY}${cyc}" NONE "${FIXwafs}/wafs/wafs_blending_0p25_admin_msg" "${COMOUTwmo}/iscs_0p25_admin_msg"
+        make_NTC_file.pl NOXX10 KKCI "${PDY}${cyc}" NONE "./wafs_blending_0p25_admin_msg" "${COMOUTwmo}/wifs_0p25_admin_msg"
+        make_NTC_file.pl NOXX10 KWBC "${PDY}${cyc}" NONE "./wafs_blending_0p25_admin_msg" "${COMOUTwmo}/iscs_0p25_admin_msg"
         if [[ "${SENDDBN_NTC}" == "YES" ]]; then
             "${DBNROOT}/bin/dbn_alert" NTC_LOW WAFS "${job}" "${COMOUTwmo}/wifs_0p25_admin_msg"
             "${DBNROOT}/bin/dbn_alert" NTC_LOW WAFS "${job}" "${COMOUTwmo}/iscs_0p25_admin_msg"
@@ -184,8 +185,8 @@ elif [[ "${SEND_UK_WAFS}" == "YES" ]]; then
     #  (Alert once for each forecast hour)
     if [[ "${SEND_AWC_UK_ALERT}" == "NO" ]]; then
         echo "WARNING: Missing US data for WAFS GRIB2 0P25 blending. Send alert message to AWC ......"
-        make_NTC_file.pl NOXX10 KKCI "${PDY}${cyc}" NONE "${FIXwafs}/wafs/wafs_blending_0p25_admin_msg" "${COMOUTwmo}/wifs_0p25_admin_msg"
-        make_NTC_file.pl NOXX10 KWBC "${PDY}${cyc}" NONE "${FIXwafs}/wafs/wafs_blending_0p25_admin_msg" "${COMOUTwmo}/iscs_0p25_admin_msg"
+        make_NTC_file.pl NOXX10 KKCI "${PDY}${cyc}" NONE "./wafs_blending_0p25_admin_msg" "${COMOUTwmo}/wifs_0p25_admin_msg"
+        make_NTC_file.pl NOXX10 KWBC "${PDY}${cyc}" NONE "./wafs_blending_0p25_admin_msg" "${COMOUTwmo}/iscs_0p25_admin_msg"
         if [[ "${SENDDBN_NTC}" == "YES" ]]; then
             "${DBNROOT}/bin/dbn_alert" NTC_LOW WAFS "${job}" "${COMOUTwmo}/wifs_0p25_admin_msg"
             "${DBNROOT}/bin/dbn_alert" NTC_LOW WAFS "${job}" "${COMOUTwmo}/iscs_0p25_admin_msg"

--- a/scripts/exwafs_grib2_1p25.sh
+++ b/scripts/exwafs_grib2_1p25.sh
@@ -41,7 +41,8 @@ cd "${DATA}" || err_exit "FATAL ERROR: Could not 'cd ${DATA}'; ABORT!"
 # 1) Grib2 data for FAA
 #---------------------------
 cpreq "${GFS_MASTER}" ./gfs_master.grib2
-${WGRIB2} "./gfs_master.grib2" | grep -F -f "${FIXwafs}/wafs/grib2_gfs_awf_master.list" | ${WGRIB2} -i "./gfs_master.grib2" -grib "tmpfile_wafsf${fhr}"
+cpreq "${FIXwafs}/wafs/grib2_gfs_awf_master.list" ./
+${WGRIB2} "./gfs_master.grib2" | grep -F -f "./grib2_gfs_awf_master.list" | ${WGRIB2} -i "./gfs_master.grib2" -grib "tmpfile_wafsf${fhr}"
 
 # F006 master file has two records of 0-6 hour APCP and ACPCP each, keep only one
 # FAA APCP ACPCP: included every 6 forecast hour (0, 48], every 12 forest hour [48, 72] (controlled by ${FIXwafs}/wafs/grib2_gfs_awf_master.list)
@@ -89,9 +90,10 @@ if [[ "${wafs_timewindow}" == "YES" ]]; then
     #---------------------------
     # 3D data from "./wafs_master.grib2", on exact model pressure levels
     cpreq "${WAFS_MASTER}" ./wafs_master.grib2
-    ${WGRIB2} "./wafs_master.grib2" | grep -F -f "${FIXwafs}/wafs/grib2_wafs.gfs_master.list" | ${WGRIB2} -i "./wafs_master.grib2" -grib "tmpfile_wafsf${fhr}"
+    cpreq "${FIXwafs}/wafs/grib2_wafs.gfs_master.list" ./
+    ${WGRIB2} "./wafs_master.grib2" | grep -F -f "./grib2_wafs.gfs_master.list" | ${WGRIB2} -i "./wafs_master.grib2" -grib "tmpfile_wafsf${fhr}"
     # 2D data from "./gfs_master.grib2"
-    tail -5 "${FIXwafs}/wafs/grib2_wafs.gfs_master.list" >grib2_wafs.gfs_master.list.2D
+    tail -5 "./grib2_wafs.gfs_master.list" >grib2_wafs.gfs_master.list.2D
     ${WGRIB2} "./gfs_master.grib2" | grep -F -f grib2_wafs.gfs_master.list.2D | ${WGRIB2} -i "./gfs_master.grib2" -grib "tmpfile_wafsf${fhr}.2D"
     # Complete list of WAFS data
     cat tmpfile_wafsf${fhr}.2D >>tmpfile_wafsf${fhr}

--- a/ush/mkwfsgbl.sh
+++ b/ush/mkwfsgbl.sh
@@ -46,7 +46,8 @@ GFS_MASTER="${COMINgfs}/gfs.t${cyc}z.master.grb2f${fhr3}"
 if [[ ! -f "pgrbf${fhr}" ]]; then
 
     cpreq "${GFS_MASTER}" "./gfs_masterf${fhr}.grib2"
-    ${WGRIB2} "./gfs_masterf${fhr}.grib2" | grep -F -f "${FIXwafs}/wafs/grib_wafs.grb2to1.list" | ${WGRIB2} -i "./gfs_masterf${fhr}.grib2" -grib "masterf${fhr}"
+    cpreq "${FIXwafs}/wafs/grib_wafs.grb2to1.list" ./
+    ${WGRIB2} "./gfs_masterf${fhr}.grib2" | grep -F -f "./grib_wafs.grb2to1.list" | ${WGRIB2} -i "./gfs_masterf${fhr}.grib2" -grib "masterf${fhr}"
 
     # Change data input from 1p00 files to master files
     export opt1=' -set_grib_type same -new_grid_winds earth '
@@ -68,7 +69,8 @@ if [[ ! -f "pgrbf${fhr}" ]]; then
     ${CNVGRIB} -g21 "pgrb2f${fhr}.tmp" "pgrbf${fhr}"
 fi
 
-${COPYGB} -g3 -i0 -N${FIXwafs}/wafs/grib_wafs.namelist -x "pgrbf${fhr}" tmp
+cpreq "${FIXwafs}/wafs/grib_wafs.namelist" ./
+${COPYGB} -g3 -i0 -N"./grib_wafs.namelist" -x "pgrbf${fhr}" tmp
 mv tmp "pgrbf${fhr}"
 ${GRBINDEX} "pgrbf${fhr}" "pgrbif${fhr}"
 
@@ -88,7 +90,7 @@ else
 fi
 
 cpreq "${EXECwafs}/wafs_makewafs.x" "./wafs_makewafs.x"
-
+cpreq "${FIXwafs}/wafs/grib_wfsgfs${fhr}${sets}" "./grib_wfsgfs${fhr}${sets}"
 export pgm="wafs_makewafs.x"
 
 . prep_step
@@ -98,7 +100,7 @@ export FORT31="pgrbif${fhr}"
 export FORT51="xtrn.wfsgfs${fhr}${sets}"
 export FORT53="com.wafs${fhr}${sets}"
 
-${DATA}/${pgm} <"${FIXwafs}/wafs/grib_wfsgfs${fhr}${sets}" >>"${pgmout}" 2>errfile
+${DATA}/${pgm} <"./grib_wfsgfs${fhr}${sets}" >>"${pgmout}" 2>errfile
 export err=$?
 err_chk
 


### PR DESCRIPTION
This PR adds a sample ecflow manual for JWAFS_GFS_MANAGER.
Other jobs need to be updated with the relevant information.

The manual should adequately describe any issues that could happen and actions that the SPA can take to mitigate them.

In addition, this PR ensures `FIXwafs` files are copied to `DATA` as required by EE2.