### PR TITLE
For blending, extend waiting time window of UK data to 25 minutes

### DIFF
--- a/scripts/exwafs_grib2_0p25_blending.sh
+++ b/scripts/exwafs_grib2_0p25_blending.sh
@@ -43,7 +43,7 @@ fi
 ###############################################
 # SLEEP_TIME - Amount of time (secs) to wait for a input file before exiting
 # SLEEP_INT  - Amount of time (secs) to wait between checking for input files
-SLEEP_TIME=${SLEEP_TIME:-1200}
+SLEEP_TIME=${SLEEP_TIME:-1500}
 SLEEP_INT=${SLEEP_INT:-10}
 SLEEP_LOOP_MAX=$((SLEEP_TIME / SLEEP_INT))
 


### PR DESCRIPTION
WAFS 0P25 BLENDING job is supposed to start at T+4:30. NCO dataflow reported 99% UK data arrived by T+4:55. For this reason NCO dataflow requests to extend the waiting time window of UK data to 25 minutes.