### PR TITLE
Update UPP tag to upp_wafs_v7.0.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "sorc/wafs_upp.fd"]
   path = sorc/wafs_upp.fd
   url = https://github.com/NOAA-EMC/UPP
-  branch = release/wafs_v7
+  branch = upp_wafs_v7.0.0
   ignore = dirty


### PR DESCRIPTION
Per AWC request which is most recently updated, AWC needs icing grids on  flight levels 010, 020, 030, 040 which are additional to the operational.
No longer needs turbulence at lower level below FL100, turbulence keeps FL480
