### PR TITLE
Add ecflow manual text to .ecf files

### DIFF
--- a/docs/Release_Notes.md
+++ b/docs/Release_Notes.md
@@ -86,7 +86,6 @@ Additionally there are other changes:
 3. In ush/mkwfsgbl.sh: change input dependency from GFS pgrb2.1p00 to master file.
 4. Remove files under ush/ folder: wafs_blending.sh wafs_grib2.regrid.sh wafs_intdsk.sh
 
-docs/Release_Notes.md
 Fix Changes
 -----------
 1. Remove fix/wafs/legend folder
@@ -148,7 +147,7 @@ Product Changes
   * `gfs.tCCz.wafs_icao.grb2fFFF`
 * Filename changes
   * Renamed according to EE2 implementation standards
-  * Exceptions: files sent to UK
+  * Exceptions: files sent to UK keep the original names except forecast hour is changed to 3 digits
   * Details:
     | GFSv16                                 | wafs.v7                                  |
     | -------------------------------------- | ---------------------------------------- |

--- a/ecf/scripts/gcip/jwafs_gcip_master.ecf
+++ b/ecf/scripts/gcip/jwafs_gcip_master.ecf
@@ -52,4 +52,19 @@ fi
 
 %include <tail.h>
 %manual
+TASK: JWAFS_GCIP
+
+PURPOSE: Triggered by JWAFS_GFS_MANAGER to produce icing analysis. It needs observation data including:
+  Satellite data from $DCOMROOT/YYYYMMDD/mcidas, manditory
+  METAR dumped from BUFR by 'dumpjb', manditory
+  PIREP/ships/lightning data dumped from BUFR by 'dumpjb', optional
+  Radar data, optional
+
+This job will be triggered by time trigger at T+4:40
+This job will be triggered by JWAFS_GFS_MANAGER once GFS forecast model output, at F000 and F003 respectively, is available.
+This job will quit if satellite data is missing and/or no METAR data is dumped.
+This job will continue if radar data or PIREP/ships/lightning data is missing
+
+TROUBLESHOOTING
+This job may fail if the mandiory observation data (satellite and METAR) is missing. If the observation data becomes available, rebooting the job will work. It is ok for occasional failures.
 %end

--- a/ecf/scripts/grib/jwafs_grib_master.ecf
+++ b/ecf/scripts/grib/jwafs_grib_master.ecf
@@ -49,4 +49,14 @@ fi
 
 %include <tail.h>
 %manual
+TASK: JWAFS_GRIB
+
+PURPOSE: Triggered by JWAFS_GFS_MANAGER to produce WAFS grib1 data.
+
+This job will be triggered for each forecast hour by JWAFS_GFS_MANAGER once GFS forecast model output is available.
+This job will produce data which is saved to wmo/ folder only.
+This job will skip any intermediate forecast hour if the forecast model output is not available for that forecast hour
+
+TROUBLESHOOTING
+If this job fails, make sure GFS forecast model output is available and re-run this job for the failed forecast hour.
 %end

--- a/ecf/scripts/grib2/0p25/blending/jwafs_grib2_0p25_blending_master.ecf
+++ b/ecf/scripts/grib2/0p25/blending/jwafs_grib2_0p25_blending_master.ecf
@@ -49,4 +49,15 @@ fi
 
 %include <tail.h>
 %manual
+TASK: JWAFS_GRIB2_0P25_BLENDING
+
+PURPOSE: Triggered by JWAFS_GRIB2_0P25 to blend US and UK unblended hazard data at 0.25 degree
+
+This job will be triggered by time trigger at T+4:30.
+This job will be triggered for each forecast hour after JWAFS_GRIB2_0P25 is finished.
+This job will start blending if UK unblended data from DCOM is available; or wait up to 25 minutes for UK data.
+This job will skip any intermediate forecast hour if its upstream JWAFS_GRIB2_0P25 fails for that forecast hour.
+
+TROUBLESHOOTING
+If this job fails, make sure both its upstream JWAFS_GRIB2_0P25 output and UK data are available then re-run this job for the failed forecast hour.
 %end

--- a/ecf/scripts/grib2/0p25/jwafs_grib2_0p25_master.ecf
+++ b/ecf/scripts/grib2/0p25/jwafs_grib2_0p25_master.ecf
@@ -50,4 +50,15 @@ fi
 
 %include <tail.h>
 %manual
+TASK: JWAFS_GRIB2_0P25
+
+PURPOSE: Triggered by JWAFS_UPP to produce WAFS grid files at 0.25 degree, and trigger the blending job:
+  JWAFS_GRIB2_0P25_BLENDING
+
+This job will be triggered for each forecast hour once JWAFS_UPP is finished.
+This job will produce WAFS grid files at 0.25 degree resolution.
+This job will skip any intermediate forecast hour if GFS model output is not available or the upsteam JWAFS_UPP fails for that forecast hour.
+
+TROUBLESHOOTING
+If this job fails, make sure its upstream JWAFS_UPP output is available and re-run this job for the failed forecast hour.
 %end

--- a/ecf/scripts/grib2/1p25/jwafs_grib2_1p25_master.ecf
+++ b/ecf/scripts/grib2/1p25/jwafs_grib2_1p25_master.ecf
@@ -50,4 +50,14 @@ fi
 
 %include <tail.h>
 %manual
+TASK: JWAFS_GRIB2_1P25
+
+PURPOSE: Triggered by JWAFS_UPP to produce WAFS files on grid 45
+
+This job will be triggered for each forecast hour once JWAFS_UPP is finished.
+This job will produce WAFS files on grid 45 , which is at 1.25 degree.
+This job will skip any intermediate forecast hour if GFS model output is not available or the upsteam JWAFS_UPP fails for that forecast hour.
+
+TROUBLESHOOTING
+If this job fails, make sure its upstream JWAFS_UPP output is available and re-run this job for the failed forecast hour.
 %end

--- a/ecf/scripts/jwafs_gfs_manager.ecf
+++ b/ecf/scripts/jwafs_gfs_manager.ecf
@@ -42,8 +42,8 @@ TASK: JWAFS_GFS_MANAGER
 
 PURPOSE: Look for GFS forecast model output and trigger the following jobs:
   JWAFS_UPP: Offline UPP with GTG
-  JWAFS_GCIP: Icing analysis as a downstream of GFS UPP master file
-  JWAFS_GRIB: GFS WAFS GRIB1 
+  JWAFS_GCIP: Icing analysis as a downstream of GFS master file
+  JWAFS_GRIB: GFS WAFS GRIB1 product as a downstream of GFS master file
 
 This job will look for GFS forecast model output, and trigger the above jobs for each of the forecast hour that the products are desired.
 The job will timeout in 10800 seconds (3 hours) if the forecast model output is not available.

--- a/ecf/scripts/upp/jwafs_upp_master.ecf
+++ b/ecf/scripts/upp/jwafs_upp_master.ecf
@@ -56,4 +56,16 @@ fi
 
 %include <tail.h>
 %manual
+TASK: JWAFS_UPP
+
+PURPOSE: Triggered by JWAFS_GFS_MANAGER to produce WAFS master files, and trigger the following two jobs:
+  JWAFS_GRIB2_0P25
+  JWAFS_GRIB2_1P25
+
+This job will be triggered for each forecast hour by JWAFS_GFS_MANAGER once GFS forecast model output is available.
+Different from genearl UPP, this job will be with GTG to produce WAFS master files for its downstream jobs.
+This job will skip any intermediate forecast hour if the forecast model output is not available for that forecast hour
+
+TROUBLESHOOTING
+If this job fails, make sure GFS forecast model output is available and re-run this job for the failed forecast hour. To debug, make sure GTG related source code, scripts and parm files work correctly.
 %end


### PR DESCRIPTION
Following the example has been added to jwafs_gfs_manager.ecf via PR #46 , added manual text to all other .ecf files

Each manual includes:
Task - What is the name
Purpose - What it does and what should the SPA or operator do in case of failure or issues in the job.