### PR TITLE
Remove processing for fhrs = 1,2,3,4,5 for UPP in WAFS

### DIFF
--- a/ecf/def/wafs.def.tmpl
+++ b/ecf/def/wafs.def.tmpl
@@ -28,64 +28,59 @@ suite wafs@EXPID@
       family @MODELVER@
         family @CYC@
           edit CYC '@CYC@'
-          task jwafs_gfs_manager
+            task jwafs_gfs_manager
             event 1 release_wafs_upp_anl  # upp
             event 2 release_wafs_upp_000
-            event 3 release_wafs_upp_001
-            event 4 release_wafs_upp_002
-            event 5 release_wafs_upp_003
-            event 6 release_wafs_upp_004
-            event 7 release_wafs_upp_005
-            event 8 release_wafs_upp_006
-            event 9 release_wafs_upp_007
-            event 10 release_wafs_upp_008
-            event 11 release_wafs_upp_009
-            event 12 release_wafs_upp_010
-            event 13 release_wafs_upp_011
-            event 14 release_wafs_upp_012
-            event 15 release_wafs_upp_013
-            event 16 release_wafs_upp_014
-            event 17 release_wafs_upp_015
-            event 18 release_wafs_upp_016
-            event 19 release_wafs_upp_017
-            event 20 release_wafs_upp_018
-            event 21 release_wafs_upp_019
-            event 22 release_wafs_upp_020
-            event 23 release_wafs_upp_021
-            event 24 release_wafs_upp_022
-            event 25 release_wafs_upp_023
-            event 26 release_wafs_upp_024
-            event 27 release_wafs_upp_027
-            event 28 release_wafs_upp_030
-            event 29 release_wafs_upp_033
-            event 30 release_wafs_upp_036
-            event 31 release_wafs_upp_039
-            event 32 release_wafs_upp_042
-            event 33 release_wafs_upp_045
-            event 34 release_wafs_upp_048
-            event 35 release_wafs_upp_054
-            event 36 release_wafs_upp_060
-            event 37 release_wafs_upp_066
-            event 38 release_wafs_upp_072
-            event 39 release_wafs_upp_078
-            event 40 release_wafs_upp_084
-            event 41 release_wafs_upp_090
-            event 42 release_wafs_upp_096
-            event 43 release_wafs_upp_102
-            event 44 release_wafs_upp_108
-            event 45 release_wafs_upp_114
-            event 46 release_wafs_upp_120
-            event 47 release_wafs_gcip_000  # gcip
-            event 48 release_wafs_gcip_003
-            event 49 release_wafs_grib_012  # grib
-            event 50 release_wafs_grib_018
-            event 51 release_wafs_grib_024
-            event 52 release_wafs_grib_030
-            event 53 release_wafs_grib_036
-            event 54 release_wafs_grib_042
-            event 55 release_wafs_grib_048
-            event 56 release_wafs_grib_060
-            event 57 release_wafs_grib_072
+            event 3 release_wafs_upp_006
+            event 4 release_wafs_upp_007
+            event 5 release_wafs_upp_008
+            event 6 release_wafs_upp_009
+            event 7 release_wafs_upp_010
+            event 8 release_wafs_upp_011
+            event 9 release_wafs_upp_012
+            event 10 release_wafs_upp_013
+            event 11 release_wafs_upp_014
+            event 12 release_wafs_upp_015
+            event 13 release_wafs_upp_016
+            event 14 release_wafs_upp_017
+            event 15 release_wafs_upp_018
+            event 16 release_wafs_upp_019
+            event 17 release_wafs_upp_020
+            event 18 release_wafs_upp_021
+            event 19 release_wafs_upp_022
+            event 20 release_wafs_upp_023
+            event 21 release_wafs_upp_024
+            event 22 release_wafs_upp_027
+            event 23 release_wafs_upp_030
+            event 24 release_wafs_upp_033
+            event 25 release_wafs_upp_036
+            event 26 release_wafs_upp_039
+            event 27 release_wafs_upp_042
+            event 28 release_wafs_upp_045
+            event 29 release_wafs_upp_048
+            event 30 release_wafs_upp_054
+            event 31 release_wafs_upp_060
+            event 32 release_wafs_upp_066
+            event 33 release_wafs_upp_072
+            event 34 release_wafs_upp_078
+            event 35 release_wafs_upp_084
+            event 36 release_wafs_upp_090
+            event 37 release_wafs_upp_096
+            event 38 release_wafs_upp_102
+            event 39 release_wafs_upp_108
+            event 40 release_wafs_upp_114
+            event 41 release_wafs_upp_120
+            event 42 release_wafs_gcip_000  # gcip
+            event 43 release_wafs_gcip_003
+            event 44 release_wafs_grib_012  # grib
+            event 45 release_wafs_grib_018
+            event 46 release_wafs_grib_024
+            event 47 release_wafs_grib_030
+            event 48 release_wafs_grib_036
+            event 49 release_wafs_grib_042
+            event 50 release_wafs_grib_048
+            event 51 release_wafs_grib_060
+            event 52 release_wafs_grib_072
           family upp
             task jwafs_upp_anl
               trigger ../jwafs_gfs_manager:release_wafs_upp_anl
@@ -93,21 +88,6 @@ suite wafs@EXPID@
             task jwafs_upp_f000
               trigger ../jwafs_gfs_manager:release_wafs_upp_000
               edit FHR 000
-            task jwafs_upp_f001
-              trigger ../jwafs_gfs_manager:release_wafs_upp_001
-              edit FHR 001
-            task jwafs_upp_f002
-              trigger ../jwafs_gfs_manager:release_wafs_upp_002
-              edit FHR 002
-            task jwafs_upp_f003
-              trigger ../jwafs_gfs_manager:release_wafs_upp_003
-              edit FHR 003
-            task jwafs_upp_f004
-              trigger ../jwafs_gfs_manager:release_wafs_upp_004
-              edit FHR 004
-            task jwafs_upp_f005
-              trigger ../jwafs_gfs_manager:release_wafs_upp_005
-              edit FHR 005
             task jwafs_upp_f006
               trigger ../jwafs_gfs_manager:release_wafs_upp_006
               edit FHR 006

--- a/ecf/def/wafs.def.tmpl
+++ b/ecf/def/wafs.def.tmpl
@@ -28,7 +28,7 @@ suite wafs@EXPID@
       family @MODELVER@
         family @CYC@
           edit CYC '@CYC@'
-            task jwafs_gfs_manager
+          task jwafs_gfs_manager
             event 1 release_wafs_upp_anl  # upp
             event 2 release_wafs_upp_000
             event 3 release_wafs_upp_006

--- a/ecf/def/wafs_nrt.def.tmpl
+++ b/ecf/def/wafs_nrt.def.tmpl
@@ -27,65 +27,60 @@ suite wafs@EXPID@
       family @MODELVER@
         family 00
           edit CYC '00'
-          task jwafs_gfs_manager
+            task jwafs_gfs_manager
             trigger :TIME >= 0335 and :TIME < 0935
             event 1 release_wafs_upp_anl  # upp
             event 2 release_wafs_upp_000
-            event 3 release_wafs_upp_001
-            event 4 release_wafs_upp_002
-            event 5 release_wafs_upp_003
-            event 6 release_wafs_upp_004
-            event 7 release_wafs_upp_005
-            event 8 release_wafs_upp_006
-            event 9 release_wafs_upp_007
-            event 10 release_wafs_upp_008
-            event 11 release_wafs_upp_009
-            event 12 release_wafs_upp_010
-            event 13 release_wafs_upp_011
-            event 14 release_wafs_upp_012
-            event 15 release_wafs_upp_013
-            event 16 release_wafs_upp_014
-            event 17 release_wafs_upp_015
-            event 18 release_wafs_upp_016
-            event 19 release_wafs_upp_017
-            event 20 release_wafs_upp_018
-            event 21 release_wafs_upp_019
-            event 22 release_wafs_upp_020
-            event 23 release_wafs_upp_021
-            event 24 release_wafs_upp_022
-            event 25 release_wafs_upp_023
-            event 26 release_wafs_upp_024
-            event 27 release_wafs_upp_027
-            event 28 release_wafs_upp_030
-            event 29 release_wafs_upp_033
-            event 30 release_wafs_upp_036
-            event 31 release_wafs_upp_039
-            event 32 release_wafs_upp_042
-            event 33 release_wafs_upp_045
-            event 34 release_wafs_upp_048
-            event 35 release_wafs_upp_054
-            event 36 release_wafs_upp_060
-            event 37 release_wafs_upp_066
-            event 38 release_wafs_upp_072
-            event 39 release_wafs_upp_078
-            event 40 release_wafs_upp_084
-            event 41 release_wafs_upp_090
-            event 42 release_wafs_upp_096
-            event 43 release_wafs_upp_102
-            event 44 release_wafs_upp_108
-            event 45 release_wafs_upp_114
-            event 46 release_wafs_upp_120
-            event 47 release_wafs_gcip_000  # gcip
-            event 48 release_wafs_gcip_003
-            event 49 release_wafs_grib_012  # grib
-            event 50 release_wafs_grib_018
-            event 51 release_wafs_grib_024
-            event 52 release_wafs_grib_030
-            event 53 release_wafs_grib_036
-            event 54 release_wafs_grib_042
-            event 55 release_wafs_grib_048
-            event 56 release_wafs_grib_060
-            event 57 release_wafs_grib_072
+            event 3 release_wafs_upp_006
+            event 4 release_wafs_upp_007
+            event 5 release_wafs_upp_008
+            event 6 release_wafs_upp_009
+            event 7 release_wafs_upp_010
+            event 8 release_wafs_upp_011
+            event 9 release_wafs_upp_012
+            event 10 release_wafs_upp_013
+            event 11 release_wafs_upp_014
+            event 12 release_wafs_upp_015
+            event 13 release_wafs_upp_016
+            event 14 release_wafs_upp_017
+            event 15 release_wafs_upp_018
+            event 16 release_wafs_upp_019
+            event 17 release_wafs_upp_020
+            event 18 release_wafs_upp_021
+            event 19 release_wafs_upp_022
+            event 20 release_wafs_upp_023
+            event 21 release_wafs_upp_024
+            event 22 release_wafs_upp_027
+            event 23 release_wafs_upp_030
+            event 24 release_wafs_upp_033
+            event 25 release_wafs_upp_036
+            event 26 release_wafs_upp_039
+            event 27 release_wafs_upp_042
+            event 28 release_wafs_upp_045
+            event 29 release_wafs_upp_048
+            event 30 release_wafs_upp_054
+            event 31 release_wafs_upp_060
+            event 32 release_wafs_upp_066
+            event 33 release_wafs_upp_072
+            event 34 release_wafs_upp_078
+            event 35 release_wafs_upp_084
+            event 36 release_wafs_upp_090
+            event 37 release_wafs_upp_096
+            event 38 release_wafs_upp_102
+            event 39 release_wafs_upp_108
+            event 40 release_wafs_upp_114
+            event 41 release_wafs_upp_120
+            event 42 release_wafs_gcip_000  # gcip
+            event 43 release_wafs_gcip_003
+            event 44 release_wafs_grib_012  # grib
+            event 45 release_wafs_grib_018
+            event 46 release_wafs_grib_024
+            event 47 release_wafs_grib_030
+            event 48 release_wafs_grib_036
+            event 49 release_wafs_grib_042
+            event 50 release_wafs_grib_048
+            event 51 release_wafs_grib_060
+            event 52 release_wafs_grib_072
           family upp
             task jwafs_upp_anl
               trigger ../jwafs_gfs_manager:release_wafs_upp_anl
@@ -93,21 +88,6 @@ suite wafs@EXPID@
             task jwafs_upp_f000
               trigger ../jwafs_gfs_manager:release_wafs_upp_000
               edit FHR 000
-            task jwafs_upp_f001
-              trigger ../jwafs_gfs_manager:release_wafs_upp_001
-              edit FHR 001
-            task jwafs_upp_f002
-              trigger ../jwafs_gfs_manager:release_wafs_upp_002
-              edit FHR 002
-            task jwafs_upp_f003
-              trigger ../jwafs_gfs_manager:release_wafs_upp_003
-              edit FHR 003
-            task jwafs_upp_f004
-              trigger ../jwafs_gfs_manager:release_wafs_upp_004
-              edit FHR 004
-            task jwafs_upp_f005
-              trigger ../jwafs_gfs_manager:release_wafs_upp_005
-              edit FHR 005
             task jwafs_upp_f006
               trigger ../jwafs_gfs_manager:release_wafs_upp_006
               edit FHR 006
@@ -528,65 +508,60 @@ suite wafs@EXPID@
         endfamily  # endfamily 00
         family 06
           edit CYC '06'
-          task jwafs_gfs_manager
+            task jwafs_gfs_manager
             trigger :TIME >= 0935 and :TIME < 1535
             event 1 release_wafs_upp_anl  # upp
             event 2 release_wafs_upp_000
-            event 3 release_wafs_upp_001
-            event 4 release_wafs_upp_002
-            event 5 release_wafs_upp_003
-            event 6 release_wafs_upp_004
-            event 7 release_wafs_upp_005
-            event 8 release_wafs_upp_006
-            event 9 release_wafs_upp_007
-            event 10 release_wafs_upp_008
-            event 11 release_wafs_upp_009
-            event 12 release_wafs_upp_010
-            event 13 release_wafs_upp_011
-            event 14 release_wafs_upp_012
-            event 15 release_wafs_upp_013
-            event 16 release_wafs_upp_014
-            event 17 release_wafs_upp_015
-            event 18 release_wafs_upp_016
-            event 19 release_wafs_upp_017
-            event 20 release_wafs_upp_018
-            event 21 release_wafs_upp_019
-            event 22 release_wafs_upp_020
-            event 23 release_wafs_upp_021
-            event 24 release_wafs_upp_022
-            event 25 release_wafs_upp_023
-            event 26 release_wafs_upp_024
-            event 27 release_wafs_upp_027
-            event 28 release_wafs_upp_030
-            event 29 release_wafs_upp_033
-            event 30 release_wafs_upp_036
-            event 31 release_wafs_upp_039
-            event 32 release_wafs_upp_042
-            event 33 release_wafs_upp_045
-            event 34 release_wafs_upp_048
-            event 35 release_wafs_upp_054
-            event 36 release_wafs_upp_060
-            event 37 release_wafs_upp_066
-            event 38 release_wafs_upp_072
-            event 39 release_wafs_upp_078
-            event 40 release_wafs_upp_084
-            event 41 release_wafs_upp_090
-            event 42 release_wafs_upp_096
-            event 43 release_wafs_upp_102
-            event 44 release_wafs_upp_108
-            event 45 release_wafs_upp_114
-            event 46 release_wafs_upp_120
-            event 47 release_wafs_gcip_000  # gcip
-            event 48 release_wafs_gcip_003
-            event 49 release_wafs_grib_012  # grib
-            event 50 release_wafs_grib_018
-            event 51 release_wafs_grib_024
-            event 52 release_wafs_grib_030
-            event 53 release_wafs_grib_036
-            event 54 release_wafs_grib_042
-            event 55 release_wafs_grib_048
-            event 56 release_wafs_grib_060
-            event 57 release_wafs_grib_072
+            event 3 release_wafs_upp_006
+            event 4 release_wafs_upp_007
+            event 5 release_wafs_upp_008
+            event 6 release_wafs_upp_009
+            event 7 release_wafs_upp_010
+            event 8 release_wafs_upp_011
+            event 9 release_wafs_upp_012
+            event 10 release_wafs_upp_013
+            event 11 release_wafs_upp_014
+            event 12 release_wafs_upp_015
+            event 13 release_wafs_upp_016
+            event 14 release_wafs_upp_017
+            event 15 release_wafs_upp_018
+            event 16 release_wafs_upp_019
+            event 17 release_wafs_upp_020
+            event 18 release_wafs_upp_021
+            event 19 release_wafs_upp_022
+            event 20 release_wafs_upp_023
+            event 21 release_wafs_upp_024
+            event 22 release_wafs_upp_027
+            event 23 release_wafs_upp_030
+            event 24 release_wafs_upp_033
+            event 25 release_wafs_upp_036
+            event 26 release_wafs_upp_039
+            event 27 release_wafs_upp_042
+            event 28 release_wafs_upp_045
+            event 29 release_wafs_upp_048
+            event 30 release_wafs_upp_054
+            event 31 release_wafs_upp_060
+            event 32 release_wafs_upp_066
+            event 33 release_wafs_upp_072
+            event 34 release_wafs_upp_078
+            event 35 release_wafs_upp_084
+            event 36 release_wafs_upp_090
+            event 37 release_wafs_upp_096
+            event 38 release_wafs_upp_102
+            event 39 release_wafs_upp_108
+            event 40 release_wafs_upp_114
+            event 41 release_wafs_upp_120
+            event 42 release_wafs_gcip_000  # gcip
+            event 43 release_wafs_gcip_003
+            event 44 release_wafs_grib_012  # grib
+            event 45 release_wafs_grib_018
+            event 46 release_wafs_grib_024
+            event 47 release_wafs_grib_030
+            event 48 release_wafs_grib_036
+            event 49 release_wafs_grib_042
+            event 50 release_wafs_grib_048
+            event 51 release_wafs_grib_060
+            event 52 release_wafs_grib_072
           family upp
             task jwafs_upp_anl
               trigger ../jwafs_gfs_manager:release_wafs_upp_anl
@@ -594,21 +569,6 @@ suite wafs@EXPID@
             task jwafs_upp_f000
               trigger ../jwafs_gfs_manager:release_wafs_upp_000
               edit FHR 000
-            task jwafs_upp_f001
-              trigger ../jwafs_gfs_manager:release_wafs_upp_001
-              edit FHR 001
-            task jwafs_upp_f002
-              trigger ../jwafs_gfs_manager:release_wafs_upp_002
-              edit FHR 002
-            task jwafs_upp_f003
-              trigger ../jwafs_gfs_manager:release_wafs_upp_003
-              edit FHR 003
-            task jwafs_upp_f004
-              trigger ../jwafs_gfs_manager:release_wafs_upp_004
-              edit FHR 004
-            task jwafs_upp_f005
-              trigger ../jwafs_gfs_manager:release_wafs_upp_005
-              edit FHR 005
             task jwafs_upp_f006
               trigger ../jwafs_gfs_manager:release_wafs_upp_006
               edit FHR 006
@@ -1029,65 +989,60 @@ suite wafs@EXPID@
         endfamily  # endfamily 06
         family 12
           edit CYC '12'
-          task jwafs_gfs_manager
+            task jwafs_gfs_manager
             trigger :TIME >= 1535 and :TIME < 2135
             event 1 release_wafs_upp_anl  # upp
             event 2 release_wafs_upp_000
-            event 3 release_wafs_upp_001
-            event 4 release_wafs_upp_002
-            event 5 release_wafs_upp_003
-            event 6 release_wafs_upp_004
-            event 7 release_wafs_upp_005
-            event 8 release_wafs_upp_006
-            event 9 release_wafs_upp_007
-            event 10 release_wafs_upp_008
-            event 11 release_wafs_upp_009
-            event 12 release_wafs_upp_010
-            event 13 release_wafs_upp_011
-            event 14 release_wafs_upp_012
-            event 15 release_wafs_upp_013
-            event 16 release_wafs_upp_014
-            event 17 release_wafs_upp_015
-            event 18 release_wafs_upp_016
-            event 19 release_wafs_upp_017
-            event 20 release_wafs_upp_018
-            event 21 release_wafs_upp_019
-            event 22 release_wafs_upp_020
-            event 23 release_wafs_upp_021
-            event 24 release_wafs_upp_022
-            event 25 release_wafs_upp_023
-            event 26 release_wafs_upp_024
-            event 27 release_wafs_upp_027
-            event 28 release_wafs_upp_030
-            event 29 release_wafs_upp_033
-            event 30 release_wafs_upp_036
-            event 31 release_wafs_upp_039
-            event 32 release_wafs_upp_042
-            event 33 release_wafs_upp_045
-            event 34 release_wafs_upp_048
-            event 35 release_wafs_upp_054
-            event 36 release_wafs_upp_060
-            event 37 release_wafs_upp_066
-            event 38 release_wafs_upp_072
-            event 39 release_wafs_upp_078
-            event 40 release_wafs_upp_084
-            event 41 release_wafs_upp_090
-            event 42 release_wafs_upp_096
-            event 43 release_wafs_upp_102
-            event 44 release_wafs_upp_108
-            event 45 release_wafs_upp_114
-            event 46 release_wafs_upp_120
-            event 47 release_wafs_gcip_000  # gcip
-            event 48 release_wafs_gcip_003
-            event 49 release_wafs_grib_012  # grib
-            event 50 release_wafs_grib_018
-            event 51 release_wafs_grib_024
-            event 52 release_wafs_grib_030
-            event 53 release_wafs_grib_036
-            event 54 release_wafs_grib_042
-            event 55 release_wafs_grib_048
-            event 56 release_wafs_grib_060
-            event 57 release_wafs_grib_072
+            event 3 release_wafs_upp_006
+            event 4 release_wafs_upp_007
+            event 5 release_wafs_upp_008
+            event 6 release_wafs_upp_009
+            event 7 release_wafs_upp_010
+            event 8 release_wafs_upp_011
+            event 9 release_wafs_upp_012
+            event 10 release_wafs_upp_013
+            event 11 release_wafs_upp_014
+            event 12 release_wafs_upp_015
+            event 13 release_wafs_upp_016
+            event 14 release_wafs_upp_017
+            event 15 release_wafs_upp_018
+            event 16 release_wafs_upp_019
+            event 17 release_wafs_upp_020
+            event 18 release_wafs_upp_021
+            event 19 release_wafs_upp_022
+            event 20 release_wafs_upp_023
+            event 21 release_wafs_upp_024
+            event 22 release_wafs_upp_027
+            event 23 release_wafs_upp_030
+            event 24 release_wafs_upp_033
+            event 25 release_wafs_upp_036
+            event 26 release_wafs_upp_039
+            event 27 release_wafs_upp_042
+            event 28 release_wafs_upp_045
+            event 29 release_wafs_upp_048
+            event 30 release_wafs_upp_054
+            event 31 release_wafs_upp_060
+            event 32 release_wafs_upp_066
+            event 33 release_wafs_upp_072
+            event 34 release_wafs_upp_078
+            event 35 release_wafs_upp_084
+            event 36 release_wafs_upp_090
+            event 37 release_wafs_upp_096
+            event 38 release_wafs_upp_102
+            event 39 release_wafs_upp_108
+            event 40 release_wafs_upp_114
+            event 41 release_wafs_upp_120
+            event 42 release_wafs_gcip_000  # gcip
+            event 43 release_wafs_gcip_003
+            event 44 release_wafs_grib_012  # grib
+            event 45 release_wafs_grib_018
+            event 46 release_wafs_grib_024
+            event 47 release_wafs_grib_030
+            event 48 release_wafs_grib_036
+            event 49 release_wafs_grib_042
+            event 50 release_wafs_grib_048
+            event 51 release_wafs_grib_060
+            event 52 release_wafs_grib_072
           family upp
             task jwafs_upp_anl
               trigger ../jwafs_gfs_manager:release_wafs_upp_anl
@@ -1095,21 +1050,6 @@ suite wafs@EXPID@
             task jwafs_upp_f000
               trigger ../jwafs_gfs_manager:release_wafs_upp_000
               edit FHR 000
-            task jwafs_upp_f001
-              trigger ../jwafs_gfs_manager:release_wafs_upp_001
-              edit FHR 001
-            task jwafs_upp_f002
-              trigger ../jwafs_gfs_manager:release_wafs_upp_002
-              edit FHR 002
-            task jwafs_upp_f003
-              trigger ../jwafs_gfs_manager:release_wafs_upp_003
-              edit FHR 003
-            task jwafs_upp_f004
-              trigger ../jwafs_gfs_manager:release_wafs_upp_004
-              edit FHR 004
-            task jwafs_upp_f005
-              trigger ../jwafs_gfs_manager:release_wafs_upp_005
-              edit FHR 005
             task jwafs_upp_f006
               trigger ../jwafs_gfs_manager:release_wafs_upp_006
               edit FHR 006
@@ -1530,65 +1470,60 @@ suite wafs@EXPID@
         endfamily  # endfamily 12
         family 18
           edit CYC '18'
-          task jwafs_gfs_manager
+            task jwafs_gfs_manager
             trigger :TIME >= 2135
             event 1 release_wafs_upp_anl  # upp
             event 2 release_wafs_upp_000
-            event 3 release_wafs_upp_001
-            event 4 release_wafs_upp_002
-            event 5 release_wafs_upp_003
-            event 6 release_wafs_upp_004
-            event 7 release_wafs_upp_005
-            event 8 release_wafs_upp_006
-            event 9 release_wafs_upp_007
-            event 10 release_wafs_upp_008
-            event 11 release_wafs_upp_009
-            event 12 release_wafs_upp_010
-            event 13 release_wafs_upp_011
-            event 14 release_wafs_upp_012
-            event 15 release_wafs_upp_013
-            event 16 release_wafs_upp_014
-            event 17 release_wafs_upp_015
-            event 18 release_wafs_upp_016
-            event 19 release_wafs_upp_017
-            event 20 release_wafs_upp_018
-            event 21 release_wafs_upp_019
-            event 22 release_wafs_upp_020
-            event 23 release_wafs_upp_021
-            event 24 release_wafs_upp_022
-            event 25 release_wafs_upp_023
-            event 26 release_wafs_upp_024
-            event 27 release_wafs_upp_027
-            event 28 release_wafs_upp_030
-            event 29 release_wafs_upp_033
-            event 30 release_wafs_upp_036
-            event 31 release_wafs_upp_039
-            event 32 release_wafs_upp_042
-            event 33 release_wafs_upp_045
-            event 34 release_wafs_upp_048
-            event 35 release_wafs_upp_054
-            event 36 release_wafs_upp_060
-            event 37 release_wafs_upp_066
-            event 38 release_wafs_upp_072
-            event 39 release_wafs_upp_078
-            event 40 release_wafs_upp_084
-            event 41 release_wafs_upp_090
-            event 42 release_wafs_upp_096
-            event 43 release_wafs_upp_102
-            event 44 release_wafs_upp_108
-            event 45 release_wafs_upp_114
-            event 46 release_wafs_upp_120
-            event 47 release_wafs_gcip_000  # gcip
-            event 48 release_wafs_gcip_003
-            event 49 release_wafs_grib_012  # grib
-            event 50 release_wafs_grib_018
-            event 51 release_wafs_grib_024
-            event 52 release_wafs_grib_030
-            event 53 release_wafs_grib_036
-            event 54 release_wafs_grib_042
-            event 55 release_wafs_grib_048
-            event 56 release_wafs_grib_060
-            event 57 release_wafs_grib_072
+            event 3 release_wafs_upp_006
+            event 4 release_wafs_upp_007
+            event 5 release_wafs_upp_008
+            event 6 release_wafs_upp_009
+            event 7 release_wafs_upp_010
+            event 8 release_wafs_upp_011
+            event 9 release_wafs_upp_012
+            event 10 release_wafs_upp_013
+            event 11 release_wafs_upp_014
+            event 12 release_wafs_upp_015
+            event 13 release_wafs_upp_016
+            event 14 release_wafs_upp_017
+            event 15 release_wafs_upp_018
+            event 16 release_wafs_upp_019
+            event 17 release_wafs_upp_020
+            event 18 release_wafs_upp_021
+            event 19 release_wafs_upp_022
+            event 20 release_wafs_upp_023
+            event 21 release_wafs_upp_024
+            event 22 release_wafs_upp_027
+            event 23 release_wafs_upp_030
+            event 24 release_wafs_upp_033
+            event 25 release_wafs_upp_036
+            event 26 release_wafs_upp_039
+            event 27 release_wafs_upp_042
+            event 28 release_wafs_upp_045
+            event 29 release_wafs_upp_048
+            event 30 release_wafs_upp_054
+            event 31 release_wafs_upp_060
+            event 32 release_wafs_upp_066
+            event 33 release_wafs_upp_072
+            event 34 release_wafs_upp_078
+            event 35 release_wafs_upp_084
+            event 36 release_wafs_upp_090
+            event 37 release_wafs_upp_096
+            event 38 release_wafs_upp_102
+            event 39 release_wafs_upp_108
+            event 40 release_wafs_upp_114
+            event 41 release_wafs_upp_120
+            event 42 release_wafs_gcip_000  # gcip
+            event 43 release_wafs_gcip_003
+            event 44 release_wafs_grib_012  # grib
+            event 45 release_wafs_grib_018
+            event 46 release_wafs_grib_024
+            event 47 release_wafs_grib_030
+            event 48 release_wafs_grib_036
+            event 49 release_wafs_grib_042
+            event 50 release_wafs_grib_048
+            event 51 release_wafs_grib_060
+            event 52 release_wafs_grib_072
           family upp
             task jwafs_upp_anl
               trigger ../jwafs_gfs_manager:release_wafs_upp_anl
@@ -1596,21 +1531,6 @@ suite wafs@EXPID@
             task jwafs_upp_f000
               trigger ../jwafs_gfs_manager:release_wafs_upp_000
               edit FHR 000
-            task jwafs_upp_f001
-              trigger ../jwafs_gfs_manager:release_wafs_upp_001
-              edit FHR 001
-            task jwafs_upp_f002
-              trigger ../jwafs_gfs_manager:release_wafs_upp_002
-              edit FHR 002
-            task jwafs_upp_f003
-              trigger ../jwafs_gfs_manager:release_wafs_upp_003
-              edit FHR 003
-            task jwafs_upp_f004
-              trigger ../jwafs_gfs_manager:release_wafs_upp_004
-              edit FHR 004
-            task jwafs_upp_f005
-              trigger ../jwafs_gfs_manager:release_wafs_upp_005
-              edit FHR 005
             task jwafs_upp_f006
               trigger ../jwafs_gfs_manager:release_wafs_upp_006
               edit FHR 006

--- a/ecf/def/wafs_nrt.def.tmpl
+++ b/ecf/def/wafs_nrt.def.tmpl
@@ -27,7 +27,7 @@ suite wafs@EXPID@
       family @MODELVER@
         family 00
           edit CYC '00'
-            task jwafs_gfs_manager
+          task jwafs_gfs_manager
             trigger :TIME >= 0335 and :TIME < 0935
             event 1 release_wafs_upp_anl  # upp
             event 2 release_wafs_upp_000
@@ -508,7 +508,7 @@ suite wafs@EXPID@
         endfamily  # endfamily 00
         family 06
           edit CYC '06'
-            task jwafs_gfs_manager
+          task jwafs_gfs_manager
             trigger :TIME >= 0935 and :TIME < 1535
             event 1 release_wafs_upp_anl  # upp
             event 2 release_wafs_upp_000
@@ -989,7 +989,7 @@ suite wafs@EXPID@
         endfamily  # endfamily 06
         family 12
           edit CYC '12'
-            task jwafs_gfs_manager
+          task jwafs_gfs_manager
             trigger :TIME >= 1535 and :TIME < 2135
             event 1 release_wafs_upp_anl  # upp
             event 2 release_wafs_upp_000
@@ -1470,7 +1470,7 @@ suite wafs@EXPID@
         endfamily  # endfamily 12
         family 18
           edit CYC '18'
-            task jwafs_gfs_manager
+          task jwafs_gfs_manager
             trigger :TIME >= 2135
             event 1 release_wafs_upp_anl  # upp
             event 2 release_wafs_upp_000

--- a/ecf/setup_ecf_links.sh
+++ b/ecf/setup_ecf_links.sh
@@ -40,10 +40,11 @@ rm -f jwafs_upp_anl.ecf
 if [[ "${CLEAN}" != "YES" ]]; then
   ln -sf jwafs_upp_master.ecf jwafs_upp_anl.ecf
 fi
-seq1=$(seq -s ' ' 0 1 24)   # 000 -> 024; 1-hourly
+seq0="0"                    # 000
+seq1=$(seq -s ' ' 6 1 24)   # 006 -> 024; 1-hourly
 seq2=$(seq -s ' ' 27 3 48)  # 027 -> 048; 3-hourly
 seq3=$(seq -s ' ' 54 6 120) # 054 -> 120; 6-hourly
-fhrs="${seq1} ${seq2} ${seq3}"
+fhrs="${seq0} ${seq1} ${seq2} ${seq3}"
 link_master_to_fhr "jwafs_upp" "${fhrs}" "${CLEAN}"
 
 # JWAFS_GRIB2

--- a/scripts/exwafs_gfs_manager.sh
+++ b/scripts/exwafs_gfs_manager.sh
@@ -16,10 +16,11 @@ set -x
 gfs_fhrs=$(seq -s ' ' 0 1 120)
 
 # Forecast hours for JWAFS_UPP
-seq1=$(seq -s ' ' 0 1 24)   # 000 -> 024; 1-hourly
+seq0="0"                    # 000
+seq1=$(seq -s ' ' 6 1 24)   # 006 -> 024; 1-hourly
 seq2=$(seq -s ' ' 27 3 48)  # 027 -> 048; 3-hourly
 seq3=$(seq -s ' ' 54 6 120) # 054 -> 120; 6-hourly
-jwafs_upp_fhrs="${seq1} ${seq2} ${seq3}"
+jwafs_upp_fhrs="${seq0} ${seq1} ${seq2} ${seq3}"
 
 # Forecast hours for JWAFS_GRIB
 seq1=$(seq -s ' ' 12 6 48) # 012 -> 048; 6-hourly


### PR DESCRIPTION
During the running of the NRT, it was discovered that the UPP for WAFS is running needlessly for forecast hour 1-5.  There is no job in WAFS that uses this output.
This PR removes processing of these forecast hours.