### PR TITLE
Change blending job to MPMD to fix bugzilla 1593. Fix bugzilla 1226

### DIFF
--- a/dev/driver/run_JWAFS_GRIB2_0P25_BLENDING
+++ b/dev/driver/run_JWAFS_GRIB2_0P25_BLENDING
@@ -89,7 +89,7 @@ export COMROOT=/lfs/h2/emc/ptmp/$USER/wafs_dwn/$envir/com
 # export COMPATH=$COMROOT/wafs
 export COMPATH=/lfs/h2/emc/ptmp/yali.mao/wafsx001/prod/com/wafs
 
-export DATA=/lfs/h2/emc/ptmp/$USER/working_wafs.$jobid
+export DATA=/lfs/h2/emc/ptmp/$USER/working_wafs
 
 ############################################
 # run the job

--- a/dev/driver/run_JWAFS_GRIB2_0P25_BLENDING
+++ b/dev/driver/run_JWAFS_GRIB2_0P25_BLENDING
@@ -4,7 +4,7 @@
 #PBS -o /lfs/h2/emc/ptmp/yali.mao/working_wafs/log.wafs_grib2_0p25_blending
 #PBS -N wafs_blending_0p25
 #PBS -l walltime=00:30:00
-#PBS -l select=1:ncpus=1
+#PBS -l select=1:ncpus=27:mem=50GB
 #PBS -q debug
 #PBS -l debug=true
 #PBS -A GFS-DEV
@@ -58,7 +58,6 @@ export RUN=wafs
 # user defined
 ############################################
 export cyc=${cyc:-00}
-export fhr=006
 export PDY=$(cut -c 7-14 $COMROOT/date/t${cyc}z)
 
 # wafs_blending for blending icing turbulence of US and UK
@@ -88,16 +87,16 @@ export COMROOT=/lfs/h2/emc/ptmp/$USER/wafs_dwn/$envir/com
 
 # For COMIN
 # export COMPATH=$COMROOT/wafs
-export COMPATH=/lfs/h2/emc/ptmp/yali.mao/wafsxPDY/com/wafs
+export COMPATH=/lfs/h2/emc/ptmp/yali.mao/wafsx001/prod/com/wafs
 
-export DATA=/lfs/h2/emc/ptmp/$USER/working_wafs/blending.$jobid
+export DATA=/lfs/h2/emc/ptmp/$USER/working_wafs.$jobid
 
 ############################################
 # run the job
 #############################################
 # Set up mailing list
 if [[ "${envir}" != "prod" ]]; then
-    MAILTO="yali.mao@noaa.gov"
+    MAILTO="nco.spa@noaa.gov"
 fi
 export MAILTO=${MAILTO:-"nco.spa@noaa.gov,ncep.sos@noaa.gov,nco.sos@noaa.gov,nco.hpc.dataflow@noaa.gov"}
 

--- a/dev/driver/submit.run_JWAFS.sh
+++ b/dev/driver/submit.run_JWAFS.sh
@@ -8,7 +8,7 @@ readonly DIR_ROOT=$(cd "$(dirname "$(readlink -f -n "${BASH_SOURCE[0]}")")/../..
 job=${1?"Must specify a job to submit"}
 PDYcyc=${2:-"2024081918"}
 
-tmpdir=/lfs/h2/emc/ptmp/${USER}/working_wafs.$job.${PDYcyc:0:8}
+tmpdir=/lfs/h2/emc/ptmp/${USER}/working_wafs.${job}_${PDYcyc:0:8}
 mkdir -p $tmpdir
 cd $tmpdir
 
@@ -32,12 +32,7 @@ elif [ $job = 'grib2_1p25' ]; then
 elif [ $job = 'grib' ]; then
   export FHOURS=${FHOURS:-"06 12 18 24 30 36 42 48 54 60 66 72"}
 elif [ $job = 'grib2_0p25_blending' ]; then
-  export FHOUT_GFS=${FHOUT_GFS:-1}
-  if [ $FHOUT_GFS -eq 3 ]; then
-    export FHOURS=${FHOURS:-"6 9 12 15 18 21 24 27 30 33 36 39 42 45 48"}
-  else
-    export FHOURS=${FHOURS:-"6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 27 30 33 36 39 42 45 48"}
-  fi
+  export FHOURS="999"
 fi
 
 for fhr in $FHOURS; do
@@ -54,7 +49,15 @@ for fhr in $FHOURS; do
   -e "s|PDY=.*|PDY=${PDYcyc:0:8}|g" \
   -e "s|cyc=.*|cyc=${PDYcyc:8:2}|g" \
   -e "s|fhr=.*|fhr=$fhr|g" \
-  -e "s|working_wafs|working_wafs.$job.${PDYcyc:0:8}|g" \
+  -e "s|working_wafs|working_wafs.${job}_${PDYcyc:0:8}|g" \
   $jobcard >$jobcard.$fhr
-  qsub $jobcard.$fhr
+
+  # for blending
+  if ["$FHOURS" = "999" ] ; then
+      mv $jobcard.$fhr $jobcard
+      qsub  $jobcard
+  else
+      qsub $jobcard.$fhr
+  fi
 done
+

--- a/dev/driver/submit.run_JWAFS.sh
+++ b/dev/driver/submit.run_JWAFS.sh
@@ -32,7 +32,14 @@ elif [ $job = 'grib2_1p25' ]; then
 elif [ $job = 'grib' ]; then
   export FHOURS=${FHOURS:-"06 12 18 24 30 36 42 48 54 60 66 72"}
 elif [ $job = 'grib2_0p25_blending' ]; then
-  export FHOURS="999"
+  sed -e "s|log.wafs_$job|log.wafs_$job|g" \
+  -e "s|HOMEwafs=.*|HOMEwafs=$DIR_ROOT|g" \
+  -e "s|PDY=.*|PDY=${PDYcyc:0:8}|g" \
+  -e "s|cyc=.*|cyc=${PDYcyc:8:2}|g" \
+  -e "s|working_wafs|working_wafs.${job}_${PDYcyc:0:8}|g" \
+  -i $jobcard
+  qsub $jobcard
+  exit
 fi
 
 for fhr in $FHOURS; do
@@ -52,12 +59,6 @@ for fhr in $FHOURS; do
   -e "s|working_wafs|working_wafs.${job}_${PDYcyc:0:8}|g" \
   $jobcard >$jobcard.$fhr
 
-  # for blending
-  if ["$FHOURS" = "999" ] ; then
-      mv $jobcard.$fhr $jobcard
-      qsub  $jobcard
-  else
-      qsub $jobcard.$fhr
-  fi
+  qsub $jobcard.$fhr
 done
 

--- a/dev/modulefiles/wafs.sh
+++ b/dev/modulefiles/wafs.sh
@@ -6,6 +6,9 @@ module load intel/${intel_ver}
 module load PrgEnv-intel/${PrgEnvintel_ver}
 module load craype/$craype_ver
 
+module load cray-pals/$craypals_ver
+module load cfp/$cfp_ver
+
 module load libjpeg/$libjpeg_ver
 module load prod_util/$prod_util_ver
 module load prod_envir/$prod_envir_ver

--- a/docs/Release_Notes.md
+++ b/docs/Release_Notes.md
@@ -86,7 +86,9 @@ Additionally there are other changes:
 2. In exwafs_grib2_0p25.sh, only include fields at the extra levels when forecast hour is between 06 and 36 per AWC request
 3. In ush/mkwfsgbl.sh: change input dependency from GFS pgrb2.1p00 to master file.
 4. Remove files under ush/ folder: wafs_blending.sh wafs_grib2.regrid.sh wafs_intdsk.sh
-5. In exwafs_grib2_0p25_blending.sh, remove the condition of sending UK unblended data if US unblended data is missing.
+5. In exwafs_grib2_0p25_blending.sh, use MPMD for each forecast hour to call ush/wafs_grib2_0p25_blending.sh.
+   - Collect missing files from ush/wafs_grib2_0p25_blending.sh, send out warning email and dbn_alert of missing data once per cycle
+   - Add not-blended email and dbn_alert if both UK and US unblended files are missing
 
 Fix Changes
 -----------
@@ -164,7 +166,10 @@ Product Changes
     | wmo/grib2.tCCz.wafs_grbfFF.45          | wmo/grib2.wafs.tCCz.grid45.fFFF          |
     | gfs.tCCz.gcip.fFF.grib2                | wafs.tCCz.gcip.fFFF.grib2                |
     | WAFS_0p25_blended_YYYYMMDDHHfFF.grib2  | WAFS_0p25_blended_ YYYYMMDDHHfFFF.grib2  |
-  
+    | gfs.tCCz.wafs_blend_0p25_usonly.emailbody  | wafs.tCCz.wafs_blend_0p25_ukmissing.emailbody |
+    | gfs.tCCz.wafs_blend_0p25_ukonly.emailbody  | wafs.tCCz.wafs_blend_0p25_usmissing.emailbody |
+    |                                            | wafs.tCCz.wafs_blend_0p25_noblending.emailbody (new) |
+
 
 * File content changes
   * Add EDPARM CATEDR MWTURB on 127.7 mb, ICESEV on 875.1 908.1 942.1 977.2 mb to:

--- a/docs/Release_Notes.md
+++ b/docs/Release_Notes.md
@@ -79,13 +79,14 @@ First of all, filename changes according to EE2 standards:
  |                                 |   exgfs_atmos_wafs_blending.sh (removed after cleaning up)  |
  |   exwafs_gfs_manager.sh (new)   |                                                             |
  |   exwafs_upp.sh (new)           |                                                             |
+ |   ush/wafs_grib2_0p25_blending.sh (new) |                                                     |
 
 Additionally there are other changes:
 1. In exwafs_grib2_0p25_blending.sh, extend the waiting time window for UK data from 15 to 25 minutes
 2. In exwafs_grib2_0p25.sh, only include fields at the extra levels when forecast hour is between 06 and 36 per AWC request
 3. In ush/mkwfsgbl.sh: change input dependency from GFS pgrb2.1p00 to master file.
 4. Remove files under ush/ folder: wafs_blending.sh wafs_grib2.regrid.sh wafs_intdsk.sh
-5. In exwafs_grib2_0p25_blending.sh, remove the condition of sending UK unblended data if US unblended data is missing. It won't happen because the job itself won't get triggered if US unblended data is missing
+5. In exwafs_grib2_0p25_blending.sh, remove the condition of sending UK unblended data if US unblended data is missing.
 
 Fix Changes
 -----------
@@ -118,7 +119,7 @@ Environment and Resource Changes
 --------------------------------
 1. Add ecFlow to WAFS package
 2. Add UPP as a WAFS component
-3. Get rid of MPMD, each forecast hour will be run in its own job card. 
+3. Add MPMD to WAFS_GRIB2_0P25_BLENDING; For other jobs, get rid of MPMD, each forecast hour will be run in its own job card. 
 4. WAFS_GRIB job dependency is changed from GFS pgrb2.1p00 to GFS master file.
 5. WAFS_GRIB2_0P25_BLENDING runtime decreases from 4 minutes to 0.5 minutes after switching from sequential to parallel run for each forecast hour
 6. Package increases from 33M to 288M (increase due to offline UPP source)
@@ -147,8 +148,6 @@ Product Changes
 * Files to be retired
   * `gfs.tCCz.wafs_icao.grb2fFFF`
   * wafs.tCCz.master.fFFF.grib2 where FFF is from 001 to 005
-* File changes
-  * For WAFS blending when UK data is missing at multiple forecast hours, multiple files wafs.tCCz.fFFF.wafs_blend_0p25_usonly.emailbody for each forecast hour will replace one single file gfs.tCCz.wafs_blend_0p25_usonly.emailbody for the whole cycle.
 * Filename changes
   * Renamed according to EE2 implementation standards
   * Exceptions: files sent to UK keep the original names except forecast hour is changed to 3 digits

--- a/jobs/JWAFS_GRIB2_0P25_BLENDING
+++ b/jobs/JWAFS_GRIB2_0P25_BLENDING
@@ -54,6 +54,7 @@ export pgmout="OUTPUT.$$"
 ####################################
 export EXECwafs="${HOMEwafs}/exec"
 export FIXwafs="${HOMEwafs}/fix"
+export USHwafs="${HOMEwafs}/ush"
 
 #########################################################
 # print current environment

--- a/scripts/exwafs_grib2_0p25.sh
+++ b/scripts/exwafs_grib2_0p25.sh
@@ -121,7 +121,6 @@ if [[ "${SENDDBN}" == "YES" ]]; then
 
         # Unblended US WAFS data sent to UK for blending, also sent to AWC
         "${DBNROOT}/bin/dbn_alert" MODEL WAFS_0P25_UBL_GB2 "${job}" "${COMOUT}/WAFS_0p25_unblended_${PDY}${cyc}f${fhr}.grib2"
-	"${DBNROOT}/bin/dbn_alert" MODEL WAFS_0P25_UBL_GB2_WIDX "${job}" "${COMOUT}/WAFS_0p25_unblended_${PDY}${cyc}f${fhr}.grib2.idx"
     fi
 
     # WAFS U/V/T/RH data sent to the same server as the unblended data as above

--- a/scripts/exwafs_grib2_0p25.sh
+++ b/scripts/exwafs_grib2_0p25.sh
@@ -119,8 +119,9 @@ if [[ "${SENDDBN}" == "YES" ]]; then
         # Hazard WAFS data (ICESEV EDR CAT MWT on 100mb to 1000mb or on new ICAO levels) sent to AWC and to NOMADS for US stakeholders
         "${DBNROOT}/bin/dbn_alert" MODEL WAFS_AWF_0P25_GB2 "${job}" "${COMOUT}/${RUN}.t${cyc}z.awf.0p25.f${fhr}.grib2"
 
-        # Unblended US WAFS data sent to UK for blending, to the same server as 1.25 deg unblended data: wmo/grib2.tCCz.wafs_grb_wifsfFF.45
+        # Unblended US WAFS data sent to UK for blending, also sent to AWC
         "${DBNROOT}/bin/dbn_alert" MODEL WAFS_0P25_UBL_GB2 "${job}" "${COMOUT}/WAFS_0p25_unblended_${PDY}${cyc}f${fhr}.grib2"
+	"${DBNROOT}/bin/dbn_alert" MODEL WAFS_0P25_UBL_GB2_WIDX "${job}" "${COMOUT}/WAFS_0p25_unblended_${PDY}${cyc}f${fhr}.grib2.idx"
     fi
 
     # WAFS U/V/T/RH data sent to the same server as the unblended data as above

--- a/scripts/exwafs_grib2_0p25_blending.sh
+++ b/scripts/exwafs_grib2_0p25_blending.sh
@@ -18,35 +18,40 @@ set -x
 
 cd "${DATA}" || err_exit "FATAL ERROR: Could not 'cd ${DATA}'; ABORT!"
 
-fhours=${fhours:-"006 007 008 009 010 011 012 013 014 015 016 017 018 019 020 021 022 023 024 027 030 033 036 039 042 045 048"}
-np=`echo $fhours | wc -w`
-MPIRUN="mpiexec -np $np -cpu-bind verbose,core cfp"
+fhours=($(seq -s ' ' -f "%03g" 6 1 24; seq -s ' ' -f "%03g" 27 3 48))
+np=${#fhours[@]}
+MPIRUN="mpiexec -np ${np} -cpu-bind verbose,core cfp"
 
 rm -f wafsgrib2_0p25.cmdfile
-ic=0
-for fhr in $fhours ; do
-  if [[ $(echo $MPIRUN | cut -d " " -f1) = 'srun' ]] ; then
-    echo "$ic ${USHwafs}/wafs_grib2_0p25_blending.sh $fhr > $DATA/${fhr}.log 2>&1" >> wafsgrib2_0p25.cmdfile
-  else
-    echo "${USHwafs}/wafs_grib2_0p25_blending.sh $fhr > $DATA/${fhr}.log 2>&1">> wafsgrib2_0p25.cmdfile
+for fhr in ${fhours[@]}; do
+    echo "${USHwafs}/wafs_grib2_0p25_blending.sh $fhr > $DATA/${fhr}.log 2>&1">> wafsgrib2_0p25_blending.cmdfile
     export MP_PGMMODEL=mpmd
-  fi
-  ic=$(expr $ic + 1)
 done
-$MPIRUN wafsgrib2_0p25.cmdfile
+$MPIRUN wafsgrib2_0p25_blending.cmdfile
+
+export err=$? ; err_chk
+
+for fhr in ${fhours[@]}; do
+    echo "=================== log file of fhr=$fhr ==================="
+    cat "${DATA}/${fhr}.log"
+done
+echo "===================== end of log files ====================="
 
 missing_uk_files="$(find $DATA -name 'missing_uk_files*')"
+missing_us_files="$(find $DATA -name 'missing_us_file*')"
+no_blending_files="$(find $DATA -name 'no_blending_files*')"
 
-if [[ ! -z "$missing_uk_files" ]] ; then
-
-    echo "WARNING: Missing UK data for WAFS GRIB2 0P25 blending. Send alert message to AWC ......"
+if [[ ! -z "$missing_uk_files" ]] || [[ ! -z "$missing_us_files" ]] || [[ ! -z "$no_blending_files" ]] ; then
+    echo "WARNING: No WAFS GRIB2 0P25 blending. Send alert message to AWC ......"
     make_NTC_file.pl NOXX10 KKCI "${PDY}${cyc}" NONE "${FIXwafs}/wafs/wafs_blending_0p25_admin_msg" "${COMOUTwmo}/wifs_0p25_admin_msg"
     make_NTC_file.pl NOXX10 KWBC "${PDY}${cyc}" NONE "${FIXwafs}/wafs/wafs_blending_0p25_admin_msg" "${COMOUTwmo}/iscs_0p25_admin_msg"
     if [[ "${SENDDBN_NTC}" == "YES" ]]; then
         "${DBNROOT}/bin/dbn_alert" NTC_LOW WAFS "${job}" "${COMOUTwmo}/wifs_0p25_admin_msg"
         "${DBNROOT}/bin/dbn_alert" NTC_LOW WAFS "${job}" "${COMOUTwmo}/iscs_0p25_admin_msg"
     fi
+fi
 
+if [[ ! -z "$missing_uk_files" ]] ; then
     subject="WARNING! Missing UK data for WAFS GRIB2 0P25 blending, ${PDY} t${cyc}z ${job}"
     echo "*************************************************************" >mailmsg
     echo "*** WARNING! Missing UK data for WAFS GRIB2 0P25 blending ***" >>mailmsg
@@ -54,17 +59,43 @@ if [[ ! -z "$missing_uk_files" ]] ; then
     echo >>mailmsg
     echo "Send alert message to AWC ...... " >>mailmsg
     echo >>mailmsg
-    echo "All missing files:" >>mailmsg
-    echo "------------------" >>mailmsg
     for file in $missing_uk_files ; do
 	cat $file >>mailmsg
     done
 
-    cat mailmsg >"${COMOUT}/${RUN}.t${cyc}z.wafs_blend_0p25_usonly.emailbody"
-    cat "${COMOUT}/${RUN}.t${cyc}z.f${fhr}.wafs_blend_0p25_usonly.emailbody" | mail.py -s "${subject}" "${MAILTO}" -v
+    cat mailmsg >"${COMOUT}/${RUN}.t${cyc}z.wafs_blend_0p25_ukmissing.emailbody"
+    cat "${COMOUT}/${RUN}.t${cyc}z.wafs_blend_0p25_ukmissing.emailbody" | mail.py -s "${subject}" "${MAILTO}" -v
 fi
 
-for fhr in $fhours ; do
-    echo "=================== log file of fhr=$fhr ==================="
-    cat $DATA/${fhr}.log
-done
+
+if [[ ! -z "$missing_us_files" ]] ; then
+    subject="WARNING! Missing US data for WAFS GRIB2 0P25 blending, ${PDY} t${cyc}z ${job}"
+    echo "*************************************************************" >mailmsg
+    echo "*** WARNING! Missing US data for WAFS GRIB2 0P25 blending ***" >>mailmsg
+    echo "*************************************************************" >>mailmsg
+    echo >>mailmsg
+    echo "Send alert message to AWC ...... " >>mailmsg
+    echo >>mailmsg
+    for file in $missing_us_files ; do
+        cat $file >>mailmsg
+    done
+
+    cat mailmsg >"${COMOUT}/${RUN}.t${cyc}z.wafs_blend_0p25_usmissing.emailbody"
+    cat "${COMOUT}/${RUN}.t${cyc}z.wafs_blend_0p25_usmissing.emailbody" | mail.py -s "${subject}" "${MAILTO}" -v
+fi
+
+if [[ ! -z "$no_blending_files" ]] ; then
+    subject="WARNING! Not blended for WAFS GRIB2 0P25 blending, ${PDY} t${cyc}z ${job}"
+    echo "*************************************************************" >mailmsg
+    echo "*** WARNING! Not blended for WAFS GRIB2 0P25 blending     ***" >>mailmsg
+    echo "*************************************************************" >>mailmsg
+    echo >>mailmsg
+    echo "Send alert message to AWC ...... " >>mailmsg
+    echo >>mailmsg
+    for file in $no_blending_files ; do
+        cat $file >>mailmsg
+    done
+
+    cat mailmsg >"${COMOUT}/${RUN}.t${cyc}z.wafs_blend_0p25_noblending.emailbody"
+    cat "${COMOUT}/${RUN}.t${cyc}z.wafs_blend_0p25_noblending.emailbody" | mail.py -s "${subject}" "${MAILTO}" -v
+fi

--- a/scripts/exwafs_grib2_0p25_blending.sh
+++ b/scripts/exwafs_grib2_0p25_blending.sh
@@ -102,4 +102,4 @@ if [[ ! -z "$no_blending_files" ]] ; then
     cat "${COMOUT}/${RUN}.t${cyc}z.wafs_blend_0p25_noblending.emailbody" | mail.py -s "${subject}" "${MAILTO}" -v
 fi
 
-export err=$? ; err_chk
+err_chk

--- a/scripts/exwafs_grib2_0p25_blending.sh
+++ b/scripts/exwafs_grib2_0p25_blending.sh
@@ -2,152 +2,69 @@
 
 ################################################################################
 #  UTILITY SCRIPT NAME :  exwafs_grib2_0p25_blending.sh
-#         DATE WRITTEN :  04/02/2020
+#         DATE WRITTEN :  10/02/2024
 #
-#  Abstract:  This script looks for US and UK WAFS Grib2 products at 1/4 deg,
-#             waits unblended UK data for specified period of time, and blends
-#             whenever UK data becomes available. After the waiting time window
-#             expires, the script sends out US data only if UK data doesn't arrive
+#  Abstract:  This script runs blending script, ush/wafs_grib2_0p25_blending.sh,
+#             using MPMD to parallel run for each forcast hour.
+#             It handles the situation of UK missing data and sends out email per cycle
 #
-#  History:  04/02/2020 - First implementation of this new script
-#            10/xx/2021 - Remove jlogfile
-#            05/25/2022 - Add ICAO new milestone Nov 2023
-#            09/08/2024 - WAFS separation
-#              - Filename changes according to EE2 standard except for files sent to UK
-#              - dbn_alert subtype is changed from gfs to WAFS
-#              - Fix bugzilla 1213: Filename should use fHHH instead of FHH.
-#              - Parallel run for each forecast hour, changed from sequential run.
+#  History:  10/02/2024 - WAFS separation
+#              - MPMD parallel run for each forecast hour, changed from sequential run.
 #              - Fix bugzilla 1593: Improve email notification for missing UK WAFS data.
-#              - Extend waiting time window from 15 to 25 minutes
-#              - usonly.emailbody is differentiated for each forecast hour with missing UK data.
-#              - Remove the condition of sending UK unblended data if US unblended data is missing. It won't happen because the job itself won't get triggered if US unblended data is missing.
+#              - Fix bugzilla 1226: Eliminate the duplicated dbn_alert for unblended wafs data
 ################################################################################
 
 set -x
 
 cd "${DATA}" || err_exit "FATAL ERROR: Could not 'cd ${DATA}'; ABORT!"
 
-SEND_UNBLENDED_US_WAFS="NO"
+fhours=${fhours:-"006 007 008 009 010 011 012 013 014 015 016 017 018 019 020 021 022 023 024 027 030 033 036 039 042 045 048"}
+np=`echo $fhours | wc -w`
+MPIRUN="mpiexec -np $np -cpu-bind verbose,core cfp"
 
-###############################################
-# Specify Timeout Behavior for WAFS blending
-###############################################
-# SLEEP_TIME - Amount of time (secs) to wait for a input file before exiting
-# SLEEP_INT  - Amount of time (secs) to wait between checking for input files
-SLEEP_TIME=${SLEEP_TIME:-1500}
-SLEEP_INT=${SLEEP_INT:-10}
-SLEEP_LOOP_MAX=$((SLEEP_TIME / SLEEP_INT))
-
-##########################
-# look for UK WAFS data.
-##########################
-for ((ic = 1; ic <= SLEEP_LOOP_MAX; ic++)); do
-    # Three(3) unblended UK files for each cycle+fhour: icing, turb, cb
-    ukfiles=$(find "${COMINuk}" -name "egrr_wafshzds_unblended_*_0p25_${PDY:0:4}-${PDY:4:2}-${PDY:6:2}T${cyc}:00Z_t${fhr}.grib2" | wc -l)
-    if ((ukfiles >= 3)); then
-        echo "Found all 3 UK WAFS GRIB2 files, continue ..."
-        break
-    fi
-
-    if ((ic == SLEEP_LOOP_MAX)); then
-        products="cb ice turb"
-        for prod in ${products}; do
-            ukfile="egrr_wafshzds_unblended_${prod}_0p25_${PDY:0:4}-${PDY:4:2}-${PDY:6:2}T${cyc}:00Z_t${fhr}.grib2"
-            if [[ ! -f "${COMINuk}/${ukfile}" ]]; then
-                echo "WARNING: UK WAFS GRIB2 file '${ukfile}' not found after waiting over ${SLEEP_TIME} seconds"
-                echo "${COMINuk}/${ukfile}" >>missing_uk_files
-            fi
-        done
-        echo "WARNING: UK WAFS GRIB2 unblended data is not completely available, no blending"
-        SEND_UNBLENDED_US_WAFS="YES"
-        break
-    else
-        sleep "${SLEEP_INT}"
-    fi
+rm -f wafsgrib2_0p25.cmdfile
+ic=0
+for fhr in $fhours ; do
+  if [[ $(echo $MPIRUN | cut -d " " -f1) = 'srun' ]] ; then
+    echo "$ic ${USHwafs}/wafs_grib2_0p25_blending.sh $fhr > $DATA/${fhr}.log 2>&1" >> wafsgrib2_0p25.cmdfile
+  else
+    echo "${USHwafs}/wafs_grib2_0p25_blending.sh $fhr > $DATA/${fhr}.log 2>&1">> wafsgrib2_0p25.cmdfile
+    export MP_PGMMODEL=mpmd
+  fi
+  ic=$(expr $ic + 1)
 done
+$MPIRUN wafsgrib2_0p25.cmdfile
 
-##########################
-# Blending or unblended
-##########################
+missing_uk_files="$(find $DATA -name 'missing_uk_files*')"
 
-if [[ "${SEND_UNBLENDED_US_WAFS}" == "YES" ]]; then
-    echo "turning back on dbn alert for unblended US WAFS product"
-else
-    # retrieve UK products
-    # Three(3) unblended UK files for each cycle+fhour: icing, turb, cb
-    cat "${COMINuk}/egrr_wafshzds_unblended_"*"_0p25_${PDY:0:4}-${PDY:4:2}-${PDY:6:2}T${cyc}:00Z_t${fhr}.grib2" >"EGRR_WAFS_0p25_unblended_${PDY}_${cyc}z_t${fhr}.grib2"
+if [[ ! -z "$missing_uk_files" ]] ; then
 
-    # pick up US data
-    cpreq "${COMINus}/WAFS_0p25_unblended_${PDY}${cyc}f${fhr}.grib2" .
-
-    # run blending code
-    export pgm="wafs_blending_0p25.x"
-
-    . prep_step
-
-    ${EXECwafs}/${pgm} "WAFS_0p25_unblended_${PDY}${cyc}f${fhr}.grib2" \
-        "EGRR_WAFS_0p25_unblended_${PDY}_${cyc}z_t${fhr}.grib2" \
-        "0p25_blended_${PDY}${cyc}f${fhr}.grib2 >f${fhr}.out"
-    err=$?
-    if ((err != 0)); then
-        echo "WARNING: WAFS blending 0p25 program failed at '${PDY}${cyc}f${fhr}'. Turning back on dbn alert for unblended US WAFS product"
-        SEND_UNBLENDED_US_WAFS="YES"
-    fi
-fi
-
-##########################
-# Data dissemination
-##########################
-if [[ "${SEND_UNBLENDED_US_WAFS}" == "YES" ]]; then
-
-    #  checking any US WAFS product was sent due to No UK WAFS GRIB2 file or WAFS blending program
-    #  (Alert once for each forecast hour)
-    if [[ ! -f ${COMOUTwmo}/wifs_0p25_admin_msg ]]; then
-        echo "WARNING: Missing UK data for WAFS GRIB2 0P25 blending. Send alert message to AWC ......"
-        make_NTC_file.pl NOXX10 KKCI "${PDY}${cyc}" NONE "${FIXwafs}/wafs/wafs_blending_0p25_admin_msg" "${COMOUTwmo}/wifs_0p25_admin_msg"
-        make_NTC_file.pl NOXX10 KWBC "${PDY}${cyc}" NONE "${FIXwafs}/wafs/wafs_blending_0p25_admin_msg" "${COMOUTwmo}/iscs_0p25_admin_msg"
-        if [[ "${SENDDBN_NTC}" == "YES" ]]; then
-            "${DBNROOT}/bin/dbn_alert" NTC_LOW WAFS "${job}" "${COMOUTwmo}/wifs_0p25_admin_msg"
-            "${DBNROOT}/bin/dbn_alert" NTC_LOW WAFS "${job}" "${COMOUTwmo}/iscs_0p25_admin_msg"
-        fi
-
+    echo "WARNING: Missing UK data for WAFS GRIB2 0P25 blending. Send alert message to AWC ......"
+    make_NTC_file.pl NOXX10 KKCI "${PDY}${cyc}" NONE "${FIXwafs}/wafs/wafs_blending_0p25_admin_msg" "${COMOUTwmo}/wifs_0p25_admin_msg"
+    make_NTC_file.pl NOXX10 KWBC "${PDY}${cyc}" NONE "${FIXwafs}/wafs/wafs_blending_0p25_admin_msg" "${COMOUTwmo}/iscs_0p25_admin_msg"
+    if [[ "${SENDDBN_NTC}" == "YES" ]]; then
+        "${DBNROOT}/bin/dbn_alert" NTC_LOW WAFS "${job}" "${COMOUTwmo}/wifs_0p25_admin_msg"
+        "${DBNROOT}/bin/dbn_alert" NTC_LOW WAFS "${job}" "${COMOUTwmo}/iscs_0p25_admin_msg"
     fi
 
-    subject="WARNING! Missing UK data for WAFS GRIB2 0P25 blending, ${PDY} t${cyc}z f${fhr} ${job}"
+    subject="WARNING! Missing UK data for WAFS GRIB2 0P25 blending, ${PDY} t${cyc}z ${job}"
     echo "*************************************************************" >mailmsg
     echo "*** WARNING! Missing UK data for WAFS GRIB2 0P25 blending ***" >>mailmsg
     echo "*************************************************************" >>mailmsg
     echo >>mailmsg
     echo "Send alert message to AWC ...... " >>mailmsg
     echo >>mailmsg
-    echo "One or more UK WAFS GRIB2 files not found:" >>mailmsg
-    cat missing_uk_files >>mailmsg
-    echo "Skipping t${cyc}z f${fhr}..." >>mailmsg    
-    cat mailmsg >"${COMOUT}/${RUN}.t${cyc}z.f${fhr}.wafs_blend_0p25_usonly.emailbody"
+    echo "All missing files:" >>mailmsg
+    echo "------------------" >>mailmsg
+    for file in $missing_uk_files ; do
+	cat $file >>mailmsg
+    done
+
+    cat mailmsg >"${COMOUT}/${RUN}.t${cyc}z.wafs_blend_0p25_usonly.emailbody"
     cat "${COMOUT}/${RUN}.t${cyc}z.f${fhr}.wafs_blend_0p25_usonly.emailbody" | mail.py -s "${subject}" "${MAILTO}" -v
-
-    # Distribute US WAFS unblend Data to NCEP FTP Server (WOC) and TOC
-    echo "altering the unblended US WAFS products:"
-    echo " - ${COMINus}/WAFS_0p25_unblended_${PDY}${cyc}f${fhr}.grib2"
-    echo " - ${COMINus}/WAFS_0p25_unblended_${PDY}${cyc}f${fhr}.grib2.idx"
-
-    if [[ "${SENDDBN}" == "YES" ]]; then
-        "${DBNROOT}/bin/dbn_alert" MODEL WAFS_0P25_UBL_GB2 "${job}" "${COMINus}/WAFS_0p25_unblended_${PDY}${cyc}f${fhr}.grib2"
-        "${DBNROOT}/bin/dbn_alert" MODEL WAFS_0P25_UBL_GB2_WIDX "${job}" "${COMINus}/WAFS_0p25_unblended_${PDY}${cyc}f${fhr}.grib2.idx"
-    fi
-
-else
-    # Distribute US WAFS unblend Data to NCEP FTP Server (WOC) and TOC
-    if [[ "${SENDCOM}" == "YES" ]]; then
-        cpfs "0p25_blended_${PDY}${cyc}f${fhr}.grib2" "${COMOUT}/WAFS_0p25_blended_${PDY}${cyc}f${fhr}.grib2"
-    fi
-
-    if [[ "${SENDDBN_NTC}" == "YES" ]]; then
-        #   Distribute Data to NCEP FTP Server (WOC) and TOC
-        echo "No WMO header yet"
-    fi
-
-    if [[ "${SENDDBN}" == "YES" ]]; then
-        "${DBNROOT}/bin/dbn_alert" MODEL WAFS_0P25_BL_GB2 "${job}" "${COMOUT}/WAFS_0p25_blended_${PDY}${cyc}f${fhr}.grib2"
-    fi
 fi
+
+for fhr in $fhours ; do
+    echo "=================== log file of fhr=$fhr ==================="
+    cat $DATA/${fhr}.log
+done

--- a/scripts/exwafs_grib2_0p25_blending.sh
+++ b/scripts/exwafs_grib2_0p25_blending.sh
@@ -19,14 +19,14 @@ set -x
 cd "${DATA}" || err_exit "FATAL ERROR: Could not 'cd ${DATA}'; ABORT!"
 
 fhours=($(seq -s ' ' -f "%03g" 6 1 24; seq -s ' ' -f "%03g" 27 3 48))
-np=${#fhours[@]}
-MPIRUN="mpiexec -np ${np} -cpu-bind verbose,core cfp"
 
 rm -f wafsgrib2_0p25.cmdfile
 for fhr in ${fhours[@]}; do
     echo "${USHwafs}/wafs_grib2_0p25_blending.sh $fhr > $DATA/${fhr}.log 2>&1">> wafsgrib2_0p25_blending.cmdfile
-    export MP_PGMMODEL=mpmd
 done
+export MP_PGMMODEL=mpmd
+np=${#fhours[@]}
+MPIRUN="mpiexec -np ${np} -cpu-bind verbose,core cfp"
 $MPIRUN wafsgrib2_0p25_blending.cmdfile
 
 export err=$? ; err_chk
@@ -38,7 +38,7 @@ done
 echo "===================== end of log files ====================="
 
 missing_uk_files="$(find $DATA -name 'missing_uk_files*')"
-missing_us_files="$(find $DATA -name 'missing_us_file*')"
+missing_us_files="$(find $DATA -name 'missing_us_files*')"
 no_blending_files="$(find $DATA -name 'no_blending_files*')"
 
 if [[ ! -z "$missing_uk_files" ]] || [[ ! -z "$missing_us_files" ]] || [[ ! -z "$no_blending_files" ]] ; then

--- a/scripts/exwafs_grib2_0p25_blending.sh
+++ b/scripts/exwafs_grib2_0p25_blending.sh
@@ -25,11 +25,13 @@ for fhr in ${fhours[@]}; do
     echo "${USHwafs}/wafs_grib2_0p25_blending.sh $fhr > $DATA/${fhr}.log 2>&1">> wafsgrib2_0p25_blending.cmdfile
 done
 export MP_PGMMODEL=mpmd
-np=${#fhours[@]}
-MPIRUN="mpiexec -np ${np} -cpu-bind verbose,core cfp"
+MPIRUN="mpiexec -np ${#fhours[@]} -cpu-bind verbose,core cfp"
 $MPIRUN wafsgrib2_0p25_blending.cmdfile
 
-export err=$? ; err_chk
+export err=$?
+if (( err != 0 )); then
+    echo "FATAL ERROR: An error occured processing blending"
+fi
 
 for fhr in ${fhours[@]}; do
     echo "=================== log file of fhr=$fhr ==================="
@@ -99,3 +101,5 @@ if [[ ! -z "$no_blending_files" ]] ; then
     cat mailmsg >"${COMOUT}/${RUN}.t${cyc}z.wafs_blend_0p25_noblending.emailbody"
     cat "${COMOUT}/${RUN}.t${cyc}z.wafs_blend_0p25_noblending.emailbody" | mail.py -s "${subject}" "${MAILTO}" -v
 fi
+
+export err=$? ; err_chk

--- a/ush/wafs_grib2_0p25_blending.sh
+++ b/ush/wafs_grib2_0p25_blending.sh
@@ -26,7 +26,7 @@ set -x
 fhr=$1
 
 mkdir -p "${DATA}/${fhr}"
-cd "${DATA}/${fhr}" || err_exit "FATAL ERROR: Could not 'cd ${DATA}/${fhr}'; ABORT!"
+cd "${DATA}/${fhr}" || err=1
 
 ###############################################
 # Specify Timeout Behavior for WAFS blending
@@ -125,7 +125,7 @@ else
 	if (( err != 0 )); then
 	    echo "turning back on dbn alert for unblended US WAFS product"
 	    "${DBNROOT}/bin/dbn_alert" MODEL WAFS_0P25_UBL_GB2_WIDX "${job}" "${COMINus}/WAFS_0p25_unblended_${PDY}${cyc}f${fhr}.grib2.idx"
-	    echo "WAFS blending 0p25 program failed at " ${PDY}${cyc}F${ffhr} > ../no_blending_files.$fhr
+	    echo "WAFS blending 0p25 program failed at " ${PDY}${cyc}F${fhr} > ../no_blending_files.$fhr
 	else
 	    # Distribute US WAFS unblend Data to NCEP FTP Server (WOC) and TOC
 	    if [[ "${SENDCOM}" == "YES" ]]; then

--- a/ush/wafs_grib2_0p25_blending.sh
+++ b/ush/wafs_grib2_0p25_blending.sh
@@ -27,6 +27,11 @@ fhr=$1
 
 mkdir -p "${DATA}/${fhr}"
 cd "${DATA}/${fhr}" || err=1
+if (( err != 0 )); then
+  echo "FATAL ERROR: Could not 'cd ${DATA}/${fhr}'"
+  echo "WAFS blending 0p25 program failed at " ${PDY}${cyc}F${fhr} > ../no_blending_files.$fhr
+  exit 1
+fi
 
 ###############################################
 # Specify Timeout Behavior for WAFS blending

--- a/ush/wafs_grib2_0p25_blending.sh
+++ b/ush/wafs_grib2_0p25_blending.sh
@@ -25,7 +25,7 @@ set -x
 
 fhr=$1
 
-mkdir -p $DATA/$fhr
+mkdir -p "${DATA}/${fhr}"
 cd "${DATA}/${fhr}" || err_exit "FATAL ERROR: Could not 'cd ${DATA}/${fhr}'; ABORT!"
 
 ###############################################
@@ -83,7 +83,7 @@ if [[ ! -f "${COMINus}/WAFS_0p25_unblended_${PDY}${cyc}f${fhr}.grib2.idx" ]]; th
     sleep 60
     if [[ ! -f "${COMINus}/WAFS_0p25_unblended_${PDY}${cyc}f${fhr}.grib2.idx" ]]; then
 	echo "WARNING: missing US unblended data - ${COMINus}/WAFS_0p25_unblended_${PDY}${cyc}f${fhr}.grib2"
-	echo "Missing ${COMINus}/WAFS_0p25_unblended_${PDY}${cyc}f${fhr}.grib2" > ../missing_us_file.$fhr
+	echo "Missing ${COMINus}/WAFS_0p25_unblended_${PDY}${cyc}f${fhr}.grib2" > ../missing_us_files.$fhr
 	MISSING_US_WAFS="YES"
     fi
 fi
@@ -92,8 +92,8 @@ fi
 # Blending or unblended
 ##########################
 if [[ "${MISSING_UK_WAFS}" == "YES" ]] && [[ "${MISSING_US_WAFS}" == "YES" ]]; then
-    cat ../missing_uk_files.$fhr ../missing_us_file.$fhr > ../no_blending_files.$fhr
-    rm ../missing_uk_files.$fhr ../missing_us_file.$fhr
+    cat ../missing_uk_files.$fhr ../missing_us_files.$fhr > ../no_blending_files.$fhr
+    rm ../missing_uk_files.$fhr ../missing_us_files.$fhr
 elif [[ "${MISSING_UK_WAFS}" == "YES" ]]; then
     echo "turning back on dbn alert for unblended US WAFS product"
     # Avoid duplicate dbn_alert of unblended grib2 file which was done in the upstream grib2_0p25 job, fix bugzilla 1226

--- a/ush/wafs_grib2_0p25_blending.sh
+++ b/ush/wafs_grib2_0p25_blending.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+################################################################################
+#  UTILITY SCRIPT NAME :  wafs_grib2_0p25_blending.sh
+#         DATE WRITTEN :  04/02/2020
+#
+#  Abstract:  This script looks for US and UK WAFS Grib2 products at 1/4 deg,
+#             waits unblended UK data for specified period of time, and blends
+#             whenever UK data becomes available. After the waiting time window
+#             expires, the script sends out US data only if UK data doesn't arrive
+#
+#  History:  04/02/2020 - First implementation of this new script
+#            10/xx/2021 - Remove jlogfile
+#            05/25/2022 - Add ICAO new milestone Nov 2023
+#            09/08/2024 - WAFS separation
+#              - Filename changes according to EE2 standard except for files sent to UK
+#              - dbn_alert subtype is changed from gfs to WAFS
+#              - Fix bugzilla 1213: Filename should use fHHH instead of FHH.
+#              - Parallel run for each forecast hour, changed from sequential run.
+#              - Fix bugzilla 1593: Improve email notification for missing UK WAFS data.
+#              - Extend waiting time window from 15 to 25 minutes
+################################################################################
+
+set -x
+
+fhr=$1
+
+mkdir -p $DATA/$fhr
+cd "${DATA}/$fhr" || err_exit "FATAL ERROR: Could not 'cd ${DATA}/fhr'; ABORT!"
+
+SEND_UNBLENDED_US_WAFS="NO"
+
+###############################################
+# Specify Timeout Behavior for WAFS blending
+###############################################
+# SLEEP_TIME - Amount of time (secs) to wait for a input file before exiting
+# SLEEP_INT  - Amount of time (secs) to wait between checking for input files
+SLEEP_TIME=${SLEEP_TIME:-1500}
+SLEEP_INT=${SLEEP_INT:-10}
+SLEEP_LOOP_MAX=$((SLEEP_TIME / SLEEP_INT))
+
+##########################
+# look for UK WAFS data.
+##########################
+for ((ic = 1; ic <= SLEEP_LOOP_MAX; ic++)); do
+    # Three(3) unblended UK files for each cycle+fhour: icing, turb, cb
+    ukfiles=$(find "${COMINuk}" -name "egrr_wafshzds_unblended_*_0p25_${PDY:0:4}-${PDY:4:2}-${PDY:6:2}T${cyc}:00Z_t${fhr}.grib2" | wc -l)
+    if ((ukfiles >= 3)); then
+        echo "Found all 3 UK WAFS GRIB2 files, continue ..."
+        break
+    fi
+
+    if ((ic == SLEEP_LOOP_MAX)); then
+        products="cb ice turb"
+        for prod in ${products}; do
+            ukfile="egrr_wafshzds_unblended_${prod}_0p25_${PDY:0:4}-${PDY:4:2}-${PDY:6:2}T${cyc}:00Z_t${fhr}.grib2"
+            if [[ ! -f "${COMINuk}/${ukfile}" ]]; then
+                echo "WARNING: UK WAFS GRIB2 file '${ukfile}' not found after waiting over ${SLEEP_TIME} seconds"
+                echo "${COMINuk}/${ukfile}" >> ../missing_uk_files.$fhr
+            fi
+        done
+        echo "WARNING: UK WAFS GRIB2 unblended data is not completely available, no blending"
+        SEND_UNBLENDED_US_WAFS="YES"
+        break
+    else
+        sleep "${SLEEP_INT}"
+    fi
+done
+
+##########################
+# Blending or unblended
+##########################
+
+if [[ "${SEND_UNBLENDED_US_WAFS}" == "YES" ]]; then
+    echo "turning back on dbn alert for unblended US WAFS product"
+elif [[ ! -f "${COMINus}/WAFS_0p25_unblended_${PDY}${cyc}f${fhr}.grib2" ]]; then
+    echo "Warning: missing US unblended data - ${COMINus}/WAFS_0p25_unblended_${PDY}${cyc}f${fhr}.grib2 "
+    exit # Silently quit if US data is missing
+else
+    # pick up US data
+    cpreq "${COMINus}/WAFS_0p25_unblended_${PDY}${cyc}f${fhr}.grib2" .
+
+    # retrieve UK products
+    # Three(3) unblended UK files for each cycle+fhour: icing, turb, cb
+    cat "${COMINuk}/egrr_wafshzds_unblended_"*"_0p25_${PDY:0:4}-${PDY:4:2}-${PDY:6:2}T${cyc}:00Z_t${fhr}.grib2" >"EGRR_WAFS_0p25_unblended_${PDY}_${cyc}z_t${fhr}.grib2"
+    
+    # run blending code
+    export pgm="wafs_blending_0p25.x"
+
+    . prep_step
+
+    ${EXECwafs}/${pgm} "WAFS_0p25_unblended_${PDY}${cyc}f${fhr}.grib2" \
+        "EGRR_WAFS_0p25_unblended_${PDY}_${cyc}z_t${fhr}.grib2" \
+        "0p25_blended_${PDY}${cyc}f${fhr}.grib2 >f${fhr}.out"
+
+    # Distribute US WAFS unblend Data to NCEP FTP Server (WOC) and TOC
+    if [[ "${SENDCOM}" == "YES" ]]; then
+        cpfs "0p25_blended_${PDY}${cyc}f${fhr}.grib2" "${COMOUT}/WAFS_0p25_blended_${PDY}${cyc}f${fhr}.grib2"
+    fi
+
+    if [[ "${SENDDBN_NTC}" == "YES" ]]; then
+        #   Distribute Data to NCEP FTP Server (WOC) and TOC
+        echo "No WMO header yet"
+    fi
+
+    if [[ "${SENDDBN}" == "YES" ]]; then
+        "${DBNROOT}/bin/dbn_alert" MODEL WAFS_0P25_BL_GB2 "${job}" "${COMOUT}/WAFS_0p25_blended_${PDY}${cyc}f${fhr}.grib2"
+    fi
+fi

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -11,6 +11,9 @@ export craype_ver=2.7.10
 export craympich_ver=8.1.9
 export craypals_ver=1.1.3
 
+export craypals_ver=1.0.12
+export cfp_ver=2.0.4
+
 export prod_envir_ver=2.0.6
 
 export libjpeg_ver=9c

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -11,7 +11,6 @@ export craype_ver=2.7.10
 export craympich_ver=8.1.9
 export craypals_ver=1.1.3
 
-export craypals_ver=1.0.12
 export cfp_ver=2.0.4
 
 export prod_envir_ver=2.0.6


### PR DESCRIPTION
Change blending job to MPMD to fix bugzilla 1593, meanwhile fix bugzilla 1226

The MPMD change for bugzilla 1593 is for NCO who wants to receive one single email
combining all forecast hours with missing UK data

For bugzilla 1226, AWC is fine with dbn_alert of US unblended data earlier in JWAFS_GRIB2_0P25 job

Bugzilla 1593 - Improve email notification for missing UK WAFS data
Bugzilla 1226 - Eliminate the duplicated dbn_alert for unblended gfs wafs data