### PR TITLE
Update ecflow after switching blending to MPMD parallel run.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ ecf/scripts/upp/jwafs_upp_f*.ecf
 ecf/scripts/upp/jwafs_upp_anl.ecf
 ecf/scripts/grib2/1p25/jwafs_grib2_1p25_f*.ecf
 ecf/scripts/grib2/0p25/jwafs_grib2_0p25_f*.ecf
-ecf/scripts/grib2/0p25/blending/jwafs_grib2_0p25_blending_f*.ecf
 ecf/scripts/gcip/jwafs_gcip_f*.ecf
 ecf/scripts/grib/jwafs_grib_f*.ecf
 

--- a/dev/ecf/run.ecflow_pdy.sh
+++ b/dev/ecf/run.ecflow_pdy.sh
@@ -13,7 +13,7 @@
 
 set -eu
 
-echo "Usage: ./setup_ecf.sh [PDYcyc]"
+echo "Usage: ./run.ecflow_pdy.sh [PDYcyc]"
 
 PDYcyc=${1:-$(date --utc "+%Y%m%d")00}
 

--- a/ecf/def/wafs.def.tmpl
+++ b/ecf/def/wafs.def.tmpl
@@ -17,7 +17,7 @@ suite wafs@EXPID@
   edit SENDCANNEDDBN 'NO'
   edit KEEPDATA 'NO'
   edit RUN_ENVIR 'dev'
-  edit COMROOT '/lfs/h2/emc/ptmp/%USER%/wafs@EXPID@/com'
+  edit COMROOT '/lfs/h2/emc/ptmp/%USER%/wafs@EXPID@/%ENVIR%/com'
   edit DATAROOT '/lfs/h2/emc/stmp/%USER%/wafs@EXPID@/tmp'
   edit OUTPUTDIR '/lfs/h2/emc/stmp/%USER%/wafs@EXPID@/output'
   edit COMPATH '%COMROOT%/wafs'
@@ -420,87 +420,8 @@ suite wafs@EXPID@
                 edit FHR 120
               family blending
                 edit DCOMROOT '/lfs/h1/ops/dev/dcom/test'
-                task jwafs_grib2_0p25_blending_f006
-                  trigger ../jwafs_grib2_0p25_f006 == complete
-                  edit FHR 006
-                task jwafs_grib2_0p25_blending_f007
-                  trigger ../jwafs_grib2_0p25_f007 == complete
-                  edit FHR 007
-                task jwafs_grib2_0p25_blending_f008
-                  trigger ../jwafs_grib2_0p25_f008 == complete
-                  edit FHR 008
-                task jwafs_grib2_0p25_blending_f009
-                  trigger ../jwafs_grib2_0p25_f009 == complete
-                  edit FHR 009
-                task jwafs_grib2_0p25_blending_f010
-                  trigger ../jwafs_grib2_0p25_f010 == complete
-                  edit FHR 010
-                task jwafs_grib2_0p25_blending_f011
-                  trigger ../jwafs_grib2_0p25_f011 == complete
-                  edit FHR 011
-                task jwafs_grib2_0p25_blending_f012
-                  trigger ../jwafs_grib2_0p25_f012 == complete
-                  edit FHR 012
-                task jwafs_grib2_0p25_blending_f013
-                  trigger ../jwafs_grib2_0p25_f013 == complete
-                  edit FHR 013
-                task jwafs_grib2_0p25_blending_f014
-                  trigger ../jwafs_grib2_0p25_f014 == complete
-                  edit FHR 014
-                task jwafs_grib2_0p25_blending_f015
-                  trigger ../jwafs_grib2_0p25_f015 == complete
-                  edit FHR 015
-                task jwafs_grib2_0p25_blending_f016
-                  trigger ../jwafs_grib2_0p25_f016 == complete
-                  edit FHR 016
-                task jwafs_grib2_0p25_blending_f017
-                  trigger ../jwafs_grib2_0p25_f017 == complete
-                  edit FHR 017
-                task jwafs_grib2_0p25_blending_f018
-                  trigger ../jwafs_grib2_0p25_f018 == complete
-                  edit FHR 018
-                task jwafs_grib2_0p25_blending_f019
-                  trigger ../jwafs_grib2_0p25_f019 == complete
-                  edit FHR 019
-                task jwafs_grib2_0p25_blending_f020
-                  trigger ../jwafs_grib2_0p25_f020 == complete
-                  edit FHR 020
-                task jwafs_grib2_0p25_blending_f021
-                  trigger ../jwafs_grib2_0p25_f021 == complete
-                  edit FHR 021
-                task jwafs_grib2_0p25_blending_f022
-                  trigger ../jwafs_grib2_0p25_f022 == complete
-                  edit FHR 022
-                task jwafs_grib2_0p25_blending_f023
-                  trigger ../jwafs_grib2_0p25_f023 == complete
-                  edit FHR 023
-                task jwafs_grib2_0p25_blending_f024
-                  trigger ../jwafs_grib2_0p25_f024 == complete
-                  edit FHR 024
-                task jwafs_grib2_0p25_blending_f027
-                  trigger ../jwafs_grib2_0p25_f027 == complete
-                  edit FHR 027
-                task jwafs_grib2_0p25_blending_f030
-                  trigger ../jwafs_grib2_0p25_f030 == complete
-                  edit FHR 030
-                task jwafs_grib2_0p25_blending_f033
-                  trigger ../jwafs_grib2_0p25_f033 == complete
-                  edit FHR 033
-                task jwafs_grib2_0p25_blending_f036
-                  trigger ../jwafs_grib2_0p25_f036 == complete
-                  edit FHR 036
-                task jwafs_grib2_0p25_blending_f039
-                  trigger ../jwafs_grib2_0p25_f039 == complete
-                  edit FHR 039
-                task jwafs_grib2_0p25_blending_f042
-                  trigger ../jwafs_grib2_0p25_f042 == complete
-                  edit FHR 042
-                task jwafs_grib2_0p25_blending_f045
-                  trigger ../jwafs_grib2_0p25_f045 == complete
-                  edit FHR 045
-                task jwafs_grib2_0p25_blending_f048
+                task jwafs_grib2_0p25_blending
                   trigger ../jwafs_grib2_0p25_f048 == complete
-                  edit FHR 048
               endfamily  # endfamily blending
             endfamily  # endfamily 0p25
           endfamily  # endfamily grib2

--- a/ecf/def/wafs_nrt.def.tmpl
+++ b/ecf/def/wafs_nrt.def.tmpl
@@ -16,7 +16,7 @@ suite wafs@EXPID@
   edit SENDCANNEDDBN 'NO'
   edit KEEPDATA 'NO'
   edit RUN_ENVIR 'dev'
-  edit COMROOT '/lfs/h2/emc/ptmp/%USER%/wafs@EXPID@/com'
+  edit COMROOT '/lfs/h2/emc/ptmp/%USER%/wafs@EXPID@/%ENVIR%/com'
   edit DATAROOT '/lfs/h2/emc/stmp/%USER%/wafs@EXPID@/tmp'
   edit OUTPUTDIR '/lfs/h2/emc/stmp/%USER%/wafs@EXPID@/output'
   edit COMPATH '%COMROOT%/wafs'
@@ -422,87 +422,8 @@ suite wafs@EXPID@
               family blending
                 trigger :TIME >= 0430 and :TIME < 1030
                 edit DCOMROOT '/lfs/h1/ops/dev/dcom/test'
-                task jwafs_grib2_0p25_blending_f006
-                  trigger ../jwafs_grib2_0p25_f006 == complete
-                  edit FHR 006
-                task jwafs_grib2_0p25_blending_f007
-                  trigger ../jwafs_grib2_0p25_f007 == complete
-                  edit FHR 007
-                task jwafs_grib2_0p25_blending_f008
-                  trigger ../jwafs_grib2_0p25_f008 == complete
-                  edit FHR 008
-                task jwafs_grib2_0p25_blending_f009
-                  trigger ../jwafs_grib2_0p25_f009 == complete
-                  edit FHR 009
-                task jwafs_grib2_0p25_blending_f010
-                  trigger ../jwafs_grib2_0p25_f010 == complete
-                  edit FHR 010
-                task jwafs_grib2_0p25_blending_f011
-                  trigger ../jwafs_grib2_0p25_f011 == complete
-                  edit FHR 011
-                task jwafs_grib2_0p25_blending_f012
-                  trigger ../jwafs_grib2_0p25_f012 == complete
-                  edit FHR 012
-                task jwafs_grib2_0p25_blending_f013
-                  trigger ../jwafs_grib2_0p25_f013 == complete
-                  edit FHR 013
-                task jwafs_grib2_0p25_blending_f014
-                  trigger ../jwafs_grib2_0p25_f014 == complete
-                  edit FHR 014
-                task jwafs_grib2_0p25_blending_f015
-                  trigger ../jwafs_grib2_0p25_f015 == complete
-                  edit FHR 015
-                task jwafs_grib2_0p25_blending_f016
-                  trigger ../jwafs_grib2_0p25_f016 == complete
-                  edit FHR 016
-                task jwafs_grib2_0p25_blending_f017
-                  trigger ../jwafs_grib2_0p25_f017 == complete
-                  edit FHR 017
-                task jwafs_grib2_0p25_blending_f018
-                  trigger ../jwafs_grib2_0p25_f018 == complete
-                  edit FHR 018
-                task jwafs_grib2_0p25_blending_f019
-                  trigger ../jwafs_grib2_0p25_f019 == complete
-                  edit FHR 019
-                task jwafs_grib2_0p25_blending_f020
-                  trigger ../jwafs_grib2_0p25_f020 == complete
-                  edit FHR 020
-                task jwafs_grib2_0p25_blending_f021
-                  trigger ../jwafs_grib2_0p25_f021 == complete
-                  edit FHR 021
-                task jwafs_grib2_0p25_blending_f022
-                  trigger ../jwafs_grib2_0p25_f022 == complete
-                  edit FHR 022
-                task jwafs_grib2_0p25_blending_f023
-                  trigger ../jwafs_grib2_0p25_f023 == complete
-                  edit FHR 023
-                task jwafs_grib2_0p25_blending_f024
-                  trigger ../jwafs_grib2_0p25_f024 == complete
-                  edit FHR 024
-                task jwafs_grib2_0p25_blending_f027
-                  trigger ../jwafs_grib2_0p25_f027 == complete
-                  edit FHR 027
-                task jwafs_grib2_0p25_blending_f030
-                  trigger ../jwafs_grib2_0p25_f030 == complete
-                  edit FHR 030
-                task jwafs_grib2_0p25_blending_f033
-                  trigger ../jwafs_grib2_0p25_f033 == complete
-                  edit FHR 033
-                task jwafs_grib2_0p25_blending_f036
-                  trigger ../jwafs_grib2_0p25_f036 == complete
-                  edit FHR 036
-                task jwafs_grib2_0p25_blending_f039
-                  trigger ../jwafs_grib2_0p25_f039 == complete
-                  edit FHR 039
-                task jwafs_grib2_0p25_blending_f042
-                  trigger ../jwafs_grib2_0p25_f042 == complete
-                  edit FHR 042
-                task jwafs_grib2_0p25_blending_f045
-                  trigger ../jwafs_grib2_0p25_f045 == complete
-                  edit FHR 045
-                task jwafs_grib2_0p25_blending_f048
+                task jwafs_grib2_0p25_blending
                   trigger ../jwafs_grib2_0p25_f048 == complete
-                  edit FHR 048
               endfamily  # endfamily blending
             endfamily  # endfamily 0p25
           endfamily  # endfamily grib2
@@ -903,87 +824,8 @@ suite wafs@EXPID@
               family blending
                 trigger :TIME >= 1030 and :TIME < 1630
                 edit DCOMROOT '/lfs/h1/ops/dev/dcom/test'
-                task jwafs_grib2_0p25_blending_f006
-                  trigger ../jwafs_grib2_0p25_f006 == complete
-                  edit FHR 006
-                task jwafs_grib2_0p25_blending_f007
-                  trigger ../jwafs_grib2_0p25_f007 == complete
-                  edit FHR 007
-                task jwafs_grib2_0p25_blending_f008
-                  trigger ../jwafs_grib2_0p25_f008 == complete
-                  edit FHR 008
-                task jwafs_grib2_0p25_blending_f009
-                  trigger ../jwafs_grib2_0p25_f009 == complete
-                  edit FHR 009
-                task jwafs_grib2_0p25_blending_f010
-                  trigger ../jwafs_grib2_0p25_f010 == complete
-                  edit FHR 010
-                task jwafs_grib2_0p25_blending_f011
-                  trigger ../jwafs_grib2_0p25_f011 == complete
-                  edit FHR 011
-                task jwafs_grib2_0p25_blending_f012
-                  trigger ../jwafs_grib2_0p25_f012 == complete
-                  edit FHR 012
-                task jwafs_grib2_0p25_blending_f013
-                  trigger ../jwafs_grib2_0p25_f013 == complete
-                  edit FHR 013
-                task jwafs_grib2_0p25_blending_f014
-                  trigger ../jwafs_grib2_0p25_f014 == complete
-                  edit FHR 014
-                task jwafs_grib2_0p25_blending_f015
-                  trigger ../jwafs_grib2_0p25_f015 == complete
-                  edit FHR 015
-                task jwafs_grib2_0p25_blending_f016
-                  trigger ../jwafs_grib2_0p25_f016 == complete
-                  edit FHR 016
-                task jwafs_grib2_0p25_blending_f017
-                  trigger ../jwafs_grib2_0p25_f017 == complete
-                  edit FHR 017
-                task jwafs_grib2_0p25_blending_f018
-                  trigger ../jwafs_grib2_0p25_f018 == complete
-                  edit FHR 018
-                task jwafs_grib2_0p25_blending_f019
-                  trigger ../jwafs_grib2_0p25_f019 == complete
-                  edit FHR 019
-                task jwafs_grib2_0p25_blending_f020
-                  trigger ../jwafs_grib2_0p25_f020 == complete
-                  edit FHR 020
-                task jwafs_grib2_0p25_blending_f021
-                  trigger ../jwafs_grib2_0p25_f021 == complete
-                  edit FHR 021
-                task jwafs_grib2_0p25_blending_f022
-                  trigger ../jwafs_grib2_0p25_f022 == complete
-                  edit FHR 022
-                task jwafs_grib2_0p25_blending_f023
-                  trigger ../jwafs_grib2_0p25_f023 == complete
-                  edit FHR 023
-                task jwafs_grib2_0p25_blending_f024
-                  trigger ../jwafs_grib2_0p25_f024 == complete
-                  edit FHR 024
-                task jwafs_grib2_0p25_blending_f027
-                  trigger ../jwafs_grib2_0p25_f027 == complete
-                  edit FHR 027
-                task jwafs_grib2_0p25_blending_f030
-                  trigger ../jwafs_grib2_0p25_f030 == complete
-                  edit FHR 030
-                task jwafs_grib2_0p25_blending_f033
-                  trigger ../jwafs_grib2_0p25_f033 == complete
-                  edit FHR 033
-                task jwafs_grib2_0p25_blending_f036
-                  trigger ../jwafs_grib2_0p25_f036 == complete
-                  edit FHR 036
-                task jwafs_grib2_0p25_blending_f039
-                  trigger ../jwafs_grib2_0p25_f039 == complete
-                  edit FHR 039
-                task jwafs_grib2_0p25_blending_f042
-                  trigger ../jwafs_grib2_0p25_f042 == complete
-                  edit FHR 042
-                task jwafs_grib2_0p25_blending_f045
-                  trigger ../jwafs_grib2_0p25_f045 == complete
-                  edit FHR 045
-                task jwafs_grib2_0p25_blending_f048
+                task jwafs_grib2_0p25_blending
                   trigger ../jwafs_grib2_0p25_f048 == complete
-                  edit FHR 048
               endfamily  # endfamily blending
             endfamily  # endfamily 0p25
           endfamily  # endfamily grib2
@@ -1384,87 +1226,8 @@ suite wafs@EXPID@
               family blending
                 trigger :TIME >= 1630 and :TIME < 2230
                 edit DCOMROOT '/lfs/h1/ops/dev/dcom/test'
-                task jwafs_grib2_0p25_blending_f006
-                  trigger ../jwafs_grib2_0p25_f006 == complete
-                  edit FHR 006
-                task jwafs_grib2_0p25_blending_f007
-                  trigger ../jwafs_grib2_0p25_f007 == complete
-                  edit FHR 007
-                task jwafs_grib2_0p25_blending_f008
-                  trigger ../jwafs_grib2_0p25_f008 == complete
-                  edit FHR 008
-                task jwafs_grib2_0p25_blending_f009
-                  trigger ../jwafs_grib2_0p25_f009 == complete
-                  edit FHR 009
-                task jwafs_grib2_0p25_blending_f010
-                  trigger ../jwafs_grib2_0p25_f010 == complete
-                  edit FHR 010
-                task jwafs_grib2_0p25_blending_f011
-                  trigger ../jwafs_grib2_0p25_f011 == complete
-                  edit FHR 011
-                task jwafs_grib2_0p25_blending_f012
-                  trigger ../jwafs_grib2_0p25_f012 == complete
-                  edit FHR 012
-                task jwafs_grib2_0p25_blending_f013
-                  trigger ../jwafs_grib2_0p25_f013 == complete
-                  edit FHR 013
-                task jwafs_grib2_0p25_blending_f014
-                  trigger ../jwafs_grib2_0p25_f014 == complete
-                  edit FHR 014
-                task jwafs_grib2_0p25_blending_f015
-                  trigger ../jwafs_grib2_0p25_f015 == complete
-                  edit FHR 015
-                task jwafs_grib2_0p25_blending_f016
-                  trigger ../jwafs_grib2_0p25_f016 == complete
-                  edit FHR 016
-                task jwafs_grib2_0p25_blending_f017
-                  trigger ../jwafs_grib2_0p25_f017 == complete
-                  edit FHR 017
-                task jwafs_grib2_0p25_blending_f018
-                  trigger ../jwafs_grib2_0p25_f018 == complete
-                  edit FHR 018
-                task jwafs_grib2_0p25_blending_f019
-                  trigger ../jwafs_grib2_0p25_f019 == complete
-                  edit FHR 019
-                task jwafs_grib2_0p25_blending_f020
-                  trigger ../jwafs_grib2_0p25_f020 == complete
-                  edit FHR 020
-                task jwafs_grib2_0p25_blending_f021
-                  trigger ../jwafs_grib2_0p25_f021 == complete
-                  edit FHR 021
-                task jwafs_grib2_0p25_blending_f022
-                  trigger ../jwafs_grib2_0p25_f022 == complete
-                  edit FHR 022
-                task jwafs_grib2_0p25_blending_f023
-                  trigger ../jwafs_grib2_0p25_f023 == complete
-                  edit FHR 023
-                task jwafs_grib2_0p25_blending_f024
-                  trigger ../jwafs_grib2_0p25_f024 == complete
-                  edit FHR 024
-                task jwafs_grib2_0p25_blending_f027
-                  trigger ../jwafs_grib2_0p25_f027 == complete
-                  edit FHR 027
-                task jwafs_grib2_0p25_blending_f030
-                  trigger ../jwafs_grib2_0p25_f030 == complete
-                  edit FHR 030
-                task jwafs_grib2_0p25_blending_f033
-                  trigger ../jwafs_grib2_0p25_f033 == complete
-                  edit FHR 033
-                task jwafs_grib2_0p25_blending_f036
-                  trigger ../jwafs_grib2_0p25_f036 == complete
-                  edit FHR 036
-                task jwafs_grib2_0p25_blending_f039
-                  trigger ../jwafs_grib2_0p25_f039 == complete
-                  edit FHR 039
-                task jwafs_grib2_0p25_blending_f042
-                  trigger ../jwafs_grib2_0p25_f042 == complete
-                  edit FHR 042
-                task jwafs_grib2_0p25_blending_f045
-                  trigger ../jwafs_grib2_0p25_f045 == complete
-                  edit FHR 045
-                task jwafs_grib2_0p25_blending_f048
+                task jwafs_grib2_0p25_blending
                   trigger ../jwafs_grib2_0p25_f048 == complete
-                  edit FHR 048
               endfamily  # endfamily blending
             endfamily  # endfamily 0p25
           endfamily  # endfamily grib2
@@ -1865,87 +1628,8 @@ suite wafs@EXPID@
               family blending
                 trigger :TIME >= 2230
                 edit DCOMROOT '/lfs/h1/ops/dev/dcom/test'
-                task jwafs_grib2_0p25_blending_f006
-                  trigger ../jwafs_grib2_0p25_f006 == complete
-                  edit FHR 006
-                task jwafs_grib2_0p25_blending_f007
-                  trigger ../jwafs_grib2_0p25_f007 == complete
-                  edit FHR 007
-                task jwafs_grib2_0p25_blending_f008
-                  trigger ../jwafs_grib2_0p25_f008 == complete
-                  edit FHR 008
-                task jwafs_grib2_0p25_blending_f009
-                  trigger ../jwafs_grib2_0p25_f009 == complete
-                  edit FHR 009
-                task jwafs_grib2_0p25_blending_f010
-                  trigger ../jwafs_grib2_0p25_f010 == complete
-                  edit FHR 010
-                task jwafs_grib2_0p25_blending_f011
-                  trigger ../jwafs_grib2_0p25_f011 == complete
-                  edit FHR 011
-                task jwafs_grib2_0p25_blending_f012
-                  trigger ../jwafs_grib2_0p25_f012 == complete
-                  edit FHR 012
-                task jwafs_grib2_0p25_blending_f013
-                  trigger ../jwafs_grib2_0p25_f013 == complete
-                  edit FHR 013
-                task jwafs_grib2_0p25_blending_f014
-                  trigger ../jwafs_grib2_0p25_f014 == complete
-                  edit FHR 014
-                task jwafs_grib2_0p25_blending_f015
-                  trigger ../jwafs_grib2_0p25_f015 == complete
-                  edit FHR 015
-                task jwafs_grib2_0p25_blending_f016
-                  trigger ../jwafs_grib2_0p25_f016 == complete
-                  edit FHR 016
-                task jwafs_grib2_0p25_blending_f017
-                  trigger ../jwafs_grib2_0p25_f017 == complete
-                  edit FHR 017
-                task jwafs_grib2_0p25_blending_f018
-                  trigger ../jwafs_grib2_0p25_f018 == complete
-                  edit FHR 018
-                task jwafs_grib2_0p25_blending_f019
-                  trigger ../jwafs_grib2_0p25_f019 == complete
-                  edit FHR 019
-                task jwafs_grib2_0p25_blending_f020
-                  trigger ../jwafs_grib2_0p25_f020 == complete
-                  edit FHR 020
-                task jwafs_grib2_0p25_blending_f021
-                  trigger ../jwafs_grib2_0p25_f021 == complete
-                  edit FHR 021
-                task jwafs_grib2_0p25_blending_f022
-                  trigger ../jwafs_grib2_0p25_f022 == complete
-                  edit FHR 022
-                task jwafs_grib2_0p25_blending_f023
-                  trigger ../jwafs_grib2_0p25_f023 == complete
-                  edit FHR 023
-                task jwafs_grib2_0p25_blending_f024
-                  trigger ../jwafs_grib2_0p25_f024 == complete
-                  edit FHR 024
-                task jwafs_grib2_0p25_blending_f027
-                  trigger ../jwafs_grib2_0p25_f027 == complete
-                  edit FHR 027
-                task jwafs_grib2_0p25_blending_f030
-                  trigger ../jwafs_grib2_0p25_f030 == complete
-                  edit FHR 030
-                task jwafs_grib2_0p25_blending_f033
-                  trigger ../jwafs_grib2_0p25_f033 == complete
-                  edit FHR 033
-                task jwafs_grib2_0p25_blending_f036
-                  trigger ../jwafs_grib2_0p25_f036 == complete
-                  edit FHR 036
-                task jwafs_grib2_0p25_blending_f039
-                  trigger ../jwafs_grib2_0p25_f039 == complete
-                  edit FHR 039
-                task jwafs_grib2_0p25_blending_f042
-                  trigger ../jwafs_grib2_0p25_f042 == complete
-                  edit FHR 042
-                task jwafs_grib2_0p25_blending_f045
-                  trigger ../jwafs_grib2_0p25_f045 == complete
-                  edit FHR 045
-                task jwafs_grib2_0p25_blending_f048
+                task jwafs_grib2_0p25_blending
                   trigger ../jwafs_grib2_0p25_f048 == complete
-                  edit FHR 048
               endfamily  # endfamily blending
             endfamily  # endfamily 0p25
           endfamily  # endfamily grib2

--- a/ecf/scripts/grib2/0p25/blending/jwafs_grib2_0p25_blending.ecf
+++ b/ecf/scripts/grib2/0p25/blending/jwafs_grib2_0p25_blending.ecf
@@ -1,10 +1,10 @@
 #PBS -S /bin/bash
-#PBS -N %RUN%_grib2_0p25_blending_f%FHR%_%CYC%
+#PBS -N %RUN%_grib2_0p25_blending_%CYC%
 #PBS -j oe
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=00:30:00
-#PBS -l select=1:ncpus=1
+#PBS -l select=1:ncpus=27:mem=50GB
 #PBS -l debug=true
 
 export model=wafs
@@ -17,7 +17,6 @@ set -x
 export NET=%NET%
 export RUN=%RUN%
 export cyc=%CYC%
-export fhr=%FHR%
 
 ############################################################
 # Load modules
@@ -29,6 +28,9 @@ module load intel/${intel_ver}
 module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}
 module load util_shared/${util_shared_ver}
+
+module load cray-pals/$craypals_ver
+module load cfp/$cfp_ver
 
 module list
 set -x
@@ -60,10 +62,10 @@ TASK: JWAFS_GRIB2_0P25_BLENDING
 PURPOSE: Triggered by JWAFS_GRIB2_0P25 to blend US and UK unblended hazard data at 0.25 degree
 
 This job will be triggered by time trigger at T+4:30.
-This job will be triggered for each forecast hour after JWAFS_GRIB2_0P25 is finished.
+This job will be triggered after JWAFS_GRIB2_0P25 f048 is completed. In non real time, it will sleep/wait 60 seconds if JWAFS_GRIB2_0P25 at another forecast hour is not completed yet when f048 is completed.
+This single MPMD job will dispatch subtasks to each forecast hour, collect the subtask results and send out warning email and dbn_alert of missing data once per cycle.
 This job will start blending if UK unblended data from DCOM is available; or wait up to 25 minutes for UK data.
-This job will skip any intermediate forecast hour if its upstream JWAFS_GRIB2_0P25 fails for that forecast hour.
 
 TROUBLESHOOTING
-If this job fails, make sure both its upstream JWAFS_GRIB2_0P25 output and UK data are available then re-run this job for the failed forecast hour.
+If this job fails, make sure both its upstream JWAFS_GRIB2_0P25 output and UK data are available then re-run this job for all the forecast hours.
 %end

--- a/ecf/scripts/grib2/0p25/blending/jwafs_grib2_0p25_blending.ecf
+++ b/ecf/scripts/grib2/0p25/blending/jwafs_grib2_0p25_blending.ecf
@@ -29,8 +29,8 @@ module load libjpeg/${libjpeg_ver}
 module load grib_util/${grib_util_ver}
 module load util_shared/${util_shared_ver}
 
-module load cray-pals/$craypals_ver
-module load cfp/$cfp_ver
+module load cray-pals/${craypals_ver}
+module load cfp/${cfp_ver}
 
 module list
 set -x

--- a/ecf/setup_ecf_links.sh
+++ b/ecf/setup_ecf_links.sh
@@ -66,12 +66,6 @@ fhrs="${seq1} ${seq2} ${seq3}"
 link_master_to_fhr "jwafs_grib2_0p25" "${fhrs}" "${CLEAN}"
 
 # JWAFS_BLENDING_0P25
-cd "${ECF_DIR}/scripts/grib2/0p25/blending"
-echo "Linking grib2/0p25/blending ..."
-seq1=$(seq -s ' ' 6 1 24)  # 006 -> 024; 1-hourly
-seq2=$(seq -s ' ' 27 3 48) # 027 -> 048; 3-hourly
-fhrs="${seq1} ${seq2}"
-link_master_to_fhr "jwafs_grib2_0p25_blending" "${fhrs}" "${CLEAN}"
 
 # JWAFS_GCIP
 cd "${ECF_DIR}/scripts/gcip"


### PR DESCRIPTION
Update ecflow after switching blending to MPMD parallel run.
 1. Don't need to setup ecflow links for blending
 2. In ecflow definations, change event triggers of each forecast hour to f048 of the upstream completion
 
Change COMROOT from 'com' to '%ENVIR%/com'