### PR TITLE
Update GCIP script and parm file for NESDIS GMGSI product updates

### DIFF
--- a/parm/wafs/wafs_gcip_gfs.cfg
+++ b/parm/wafs/wafs_gcip_gfs.cfg
@@ -216,10 +216,10 @@ nfiner = 2
 #
 #satellite sources: preset values and the corresponsing longitudes
 # https://www.ssec.wisc.edu/mcidas/doc/users_guide.html
-# https://www.ssec.wisc.edu/mcidas/doc/users_guide/2018.1/app_c-1.html
+# https://www.ssec.wisc.edu/mcidas/doc/users_guide/current/app_c-1.html or https://www.ssec.wisc.edu/mcidas/doc/users_guide/2018.1/app_c-1.html
 # https://www.eumetsat.int/website/home/Satellites/CurrentSatellites/Meteosat/index.html
-#                  METEOSAT-8 METEOSAT-9 METEOSAT-10 METEOSAT-11 HIMAWARI-8  GOES-W 15   GOES-E 16  GOES-W 17   ( MTSAT-1   MTSAT-2)
-satellite_source = 51 41.5,   52 3.5,    53 9.5,     98 0.0,     86 140.7,   184 -128.0, 186 -75.2, 188 -137.2, 84 145.0,  85 145.0
+#                  METEOSAT-9(MSG2) METEOSAT-10(MSG3) METEOSAT-11(MSG4) HIMAWARI-8  HIMAWARI-9   GOES-E 16  GOES-W 17   GOES-18
+satellite_source = 52 45.5,         53 0.0,           98 9.5,           86 140.7,   31 140.7     186 -75.2, 188 -105,   190 -137.2
 # Fortran code has taken care of the well known SS numbers
 
 # for SatDerive

--- a/scripts/exgfs_atmos_wafs_gcip.sh
+++ b/scripts/exgfs_atmos_wafs_gcip.sh
@@ -94,7 +94,7 @@ if [ $RUN = "gfs" ] ; then
   channels="VIS SIR LIR SSR"
   # If one channel is missing, satFiles will be empty
   for channel in $channels ; do
-      satFile=GLOBCOMP$channel.${PDY}${vhour}
+      satFile=GLOBCOMP${channel}*${PDY}${vhour}*area
       if [[ $COMINsat == *ftp:* ]] ; then
 	  curl -O $COMINsat/$satFile
       else
@@ -134,10 +134,10 @@ if [ $RUN = "gfs" ] ; then
 	  fi
 	done
 
-	cp $COMINsat/$satFile .
+	cp $COMINsat/$satFile ${channel}.area
       fi
-      if [[ -s $satFile ]] ; then
-	  satFiles="$satFiles $satFile"
+      if [[ -s ${channel}.area ]] ; then
+	  satFiles="$satFiles ${channel}.area"
       else
 	  satFiles=""
 	  break


### PR DESCRIPTION
- Update GCIP script to work with the new filenames of Global Mosaic of Geostationary Satellite Imagery (GMGSI) products.
- Update GCIP parm file because one sensor number is new to the current GCIP configuration, and the locations of multiple senors are changed.


