### PR TITLE
Upgrade module versions according to what NCO parallel run made

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "sorc/wafs_upp.fd"]
   path = sorc/wafs_upp.fd
   url = https://github.com/NOAA-EMC/UPP
-  branch = upp_wafs_v7.0.0
+  branch = upp_wafs_v7.0.1
   ignore = dirty

--- a/versions/build.ver
+++ b/versions/build.ver
@@ -1,16 +1,16 @@
-export PrgEnv_intel_ver=8.1.0
+export PrgEnv_intel_ver=8.3.3
 export intel_ver=19.1.3.304
-export craype_ver=2.7.10
-export cray_mpich_ver=8.1.9
+export craype_ver=2.7.17
+export cray_mpich_ver=8.1.19
 export cmake_ver=3.20.2
 
 export jasper_ver=2.0.25
 export zlib_ver=1.2.11
 export libpng_ver=1.6.37
 
-export bufr_ver=11.7.0
+export bufr_ver=12.0.1
 export bacio_ver=2.4.1
 export w3emc_ver=2.9.2
-export sp_ver=2.3.3
-export ip_ver=3.3.3
+export sp_ver=2.4.0
+export ip_ver=4.1.0
 export g2_ver=3.4.5

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -5,11 +5,11 @@ export radarl2_ver=v1.2
 export bufr_dump_ver=1.1.2
 export util_shared_ver=1.4.0
 
-export PrgEnvintel_ver=8.1.0
+export PrgEnvintel_ver=8.3.3
 export intel_ver=19.1.3.304
-export craype_ver=2.7.10
-export craympich_ver=8.1.9
-export craypals_ver=1.1.3
+export craype_ver=2.7.17
+export craympich_ver=8.1.19
+export craypals_ver=1.2.2
 
 export cfp_ver=2.0.4
 
@@ -18,7 +18,7 @@ export prod_envir_ver=2.0.6
 export libjpeg_ver=9c
 export hdf5_ver=1.10.6
 export netcdf_ver=4.7.4
-export g2tmpl_ver=1.9.1
+export g2tmpl_ver=1.13.0
 export prod_util_ver=2.0.14
 export grib_util_ver=1.2.3
 export wgrib2_ver=2.0.7


### PR DESCRIPTION
NCO made the following 3 module version upgrades:
1. versions/build.ver
2. versions/run.ver
3. sorc/wafs_upp.fd/modulefiles/post/post_wcoss2.lua, which needs a new tag of WAFS UPP submodule, upp_wafs_v7.0.1