### PR TITLE
For WAFSv7, pick up NCO dbn_alert changes for blended products for operational v7.0.1

### DIFF
--- a/ecf/grib2/0p25/blending/jwafs_grib2_0p25_blending.ecf
+++ b/ecf/grib2/0p25/blending/jwafs_grib2_0p25_blending.ecf
@@ -46,7 +46,7 @@ set -x
 if [[ "${envir}" != "prod" ]]; then
     MAILTO=${MAILTO:-"nco.spa@noaa.gov"}
 fi
-export MAILTO=${MAILTO:-"nco.spa@noaa.gov,nco.sos@noaa.gov,nco.hpc.dataflow@noaa.gov"}
+export MAILTO=${MAILTO:-"nco.spa@noaa.gov,nco.sos@noaa.gov,sdm@noaa.gov,nco.hpc.dataflow@noaa.gov"}
 
 ${HOMEwafs}/jobs/JWAFS_GRIB2_0P25_BLENDING
 if [ $? -ne 0 ]; then

--- a/ush/wafs_grib2_0p25_blending.sh
+++ b/ush/wafs_grib2_0p25_blending.sh
@@ -103,7 +103,7 @@ elif [[ "${MISSING_UK_WAFS}" == "YES" ]]; then
     echo "turning back on dbn alert for unblended US WAFS product"
     # Avoid duplicate dbn_alert of unblended grib2 file which was done in the upstream grib2_0p25 job, fix bugzilla 1226
     # "${DBNROOT}/bin/dbn_alert" MODEL WAFS_0P25_UBL_GB2 "${job}" "${COMINus}/WAFS_0p25_unblended_${PDY}${cyc}f${fhr}.grib2"
-    "${DBNROOT}/bin/dbn_alert" MODEL WAFS_0P25_UBL_GB2_WIDX "${job}" "${COMINus}/WAFS_0p25_unblended_${PDY}${cyc}f${fhr}.grib2.idx"
+    # "${DBNROOT}/bin/dbn_alert" MODEL WAFS_0P25_UBL_GB2_WIDX "${job}" "${COMINus}/WAFS_0p25_unblended_${PDY}${cyc}f${fhr}.grib2.idx"
 else
     # retrieve UK products
     # Three(3) unblended UK files for each cycle+fhour: icing, turb, cb
@@ -128,8 +128,8 @@ else
 
 	err=$?
 	if (( err != 0 )); then
-	    echo "turning back on dbn alert for unblended US WAFS product"
-	    "${DBNROOT}/bin/dbn_alert" MODEL WAFS_0P25_UBL_GB2_WIDX "${job}" "${COMINus}/WAFS_0p25_unblended_${PDY}${cyc}f${fhr}.grib2.idx"
+	    #echo "turning back on dbn alert for unblended US WAFS product"
+	    #"${DBNROOT}/bin/dbn_alert" MODEL WAFS_0P25_UBL_GB2_WIDX "${job}" "${COMINus}/WAFS_0p25_unblended_${PDY}${cyc}f${fhr}.grib2.idx"
 	    echo "WAFS blending 0p25 program failed at " ${PDY}${cyc}F${fhr} > ../no_blending_files.$fhr
 	else
 	    # Distribute US WAFS unblend Data to NCEP FTP Server (WOC) and TOC

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -23,5 +23,3 @@ export prod_util_ver=2.0.14
 export grib_util_ver=1.2.3
 export wgrib2_ver=2.0.7
 
-#Turn off SBN_EVAL because the files are not public
-export SENDDBN_NTC=NO


### PR DESCRIPTION
When WAFSv7.0.1 came into operations, NCO made dbn_alert changes for 0p25 blended products by removing ".idx" dbn_alerts