### PR TITLE
For WAFSv7, add dbn_alert of GCIP for AWC

### DIFF
--- a/jobs/JWAFS_GCIP
+++ b/jobs/JWAFS_GCIP
@@ -24,6 +24,7 @@ setpdy.sh
 # SEND to COM, DBN, etc
 ####################################
 export SENDCOM=${SENDCOM:-"YES"}
+export SENDDBN=${SENDDBN:-"YES"}
 
 ####################################
 # Specify NET and RUN Name and model

--- a/scripts/exwafs_gcip.sh
+++ b/scripts/exwafs_gcip.sh
@@ -147,3 +147,8 @@ fi
 if [[ "${SENDCOM}" == "YES" ]]; then
 	cpfs "${outputfile}" "${COMOUT}/${outputfile}"
 fi
+
+# Alert via DBN
+if [[ "${SENDDBN}" == "YES" ]]; then
+    "${DBNROOT}/bin/dbn_alert" MODEL WAFS_GCIP_GB2 "${job}" "${COMOUT}/${outputfile}"
+fi

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,4 +1,4 @@
-export wafs_ver=v7.0.1
+export wafs_ver=v7.0.2
 
 export gfs_ver=v16.3
 export radarl2_ver=v1.2


### PR DESCRIPTION
Per AWC request in March 2025, add dbn_alert of GCIP to verify SigWx icing forecasts.