### PR TITLE
Subset of updates of WAFSv8 for GFSv17

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "sorc/wafs_upp.fd"]
   path = sorc/wafs_upp.fd
   url = https://github.com/NOAA-EMC/UPP
-  branch = upp_wafs_v7.0.1
+  branch = develop
   ignore = dirty

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ Software necessary to generate WAFS products
 To checkout:
 ==================================
 
-Way 1:
 Clone repository
 ```bash
 git clone https://github.com/NOAA-EMC/WAFS
@@ -12,16 +11,10 @@ git clone https://github.com/NOAA-EMC/WAFS
 
 Checkout the desired branch or tag
 
-Clone submodule and sub-submodule repository (including upp and upp/sorc/post_gtg):
+Clone submodule and sub-submodule repository (including upp and upp/sorc/ncep_post.fd/post_gtg.fd):
 (gtg code is UCAR private, access needs to be authorized)
 ```bash
 sh sorc/checkout_upp.sh
-```
-
-Way 2:
-Recursively clone repository if knowing the desired branch or tag
-```bash
-git clone --recursive -b desired_branch.or.tag  https://github.com/NOAA-EMC/WAFS
 ```
 
 To compile:
@@ -32,5 +25,4 @@ Compile the executable files:
 sh sorc/build_all.sh
 ```
 
-`build_all.sh` will copy the right files, build WAFS executables and offline UPP executable.
 

--- a/dev/driver/run_JWAFS_GCIP
+++ b/dev/driver/run_JWAFS_GCIP
@@ -20,7 +20,7 @@ set -x
 # Set up the HOME directory
 ############################################
 export NWROOT=/lfs/h2/emc/vpppg/noscrub/yali.mao/git
-export HOMEwafs=${HOMEwafs:-${NWROOT}/WAFS.fork}
+export HOMEwafs=${HOMEwafs:-${NWROOT}/wafs.fork}
 
 ############################################
 # Loading module
@@ -86,6 +86,7 @@ export KEEPDATA=YES
 
 export COMROOT=/lfs/h2/emc/ptmp/$USER/wafs_dwn/$envir/com
 
+COMPATHgfs=/lfs/h2/emc/vpppg/noscrub/yali.mao/gfsv17data/prod/com/gfs
 export COMPATH=${COMPATHgfs:-/lfs/h1/ops/prod/com/gfs}:${COMPATHradar:-/lfs/h1/ops/prod/com/radarl2}
 
 export DATA=/lfs/h2/emc/ptmp/$USER/working_wafs/gcip.$jobid

--- a/dev/driver/run_JWAFS_GRIB
+++ b/dev/driver/run_JWAFS_GRIB
@@ -20,7 +20,7 @@ set -x
 # Set up the HOME directory
 ############################################
 export NWROOT=/lfs/h2/emc/vpppg/noscrub/yali.mao/git
-export HOMEwafs=${HOMEwafs:-${NWROOT}/WAFS.fork}
+export HOMEwafs=${HOMEwafs:-${NWROOT}/wafs.fork}
 
 ############################################
 # Loading module
@@ -80,6 +80,7 @@ export KEEPDATA=YES
 
 export COMROOT=/lfs/h2/emc/ptmp/$USER/wafs_dwn/$envir/com
 
+COMPATHgfs=/lfs/h2/emc/vpppg/noscrub/yali.mao/gfsv17data/prod/com/gfs
 export COMPATH=${COMPATHgfs:-/lfs/h1/ops/prod/com/gfs}
 
 export DATA=/lfs/h2/emc/ptmp/$USER/working_wafs/grib.$jobid

--- a/dev/driver/run_JWAFS_GRIB2_0P25
+++ b/dev/driver/run_JWAFS_GRIB2_0P25
@@ -20,7 +20,7 @@ set -x
 # Set up the HOME directory
 ############################################
 export NWROOT=/lfs/h2/emc/vpppg/noscrub/yali.mao/git
-export HOMEwafs=${HOMEwafs:-${NWROOT}/WAFS.fork}
+export HOMEwafs=${HOMEwafs:-${NWROOT}/wafs.fork}
 
 ############################################
 # Loading module
@@ -81,8 +81,8 @@ export KEEPDATA=YES
 
 export COMROOT=/lfs/h2/emc/ptmp/$USER/wafs_dwn/$envir/com
 
+COMPATHgfs=/lfs/h2/emc/vpppg/noscrub/yali.mao/gfsv17data/prod/com/gfs
 export COMPATH=${COMPATHgfs:-/lfs/h1/ops/prod/com/gfs}:/lfs/h2/emc/ptmp/yali.mao/wafs_dwn/prod/com/wafs
-#/lfs/h2/emc/vpppg/noscrub/yali.mao/separation/prod/com/wafs:/lfs/h2/emc/ptmp/yali.mao/wafs_dwn/prod/com/wafs
 
 export DATA=/lfs/h2/emc/ptmp/$USER/working_wafs/grib2_0p25.$jobid
 

--- a/dev/driver/run_JWAFS_GRIB2_0P25_BLENDING
+++ b/dev/driver/run_JWAFS_GRIB2_0P25_BLENDING
@@ -19,7 +19,7 @@ set -x
 # Set up the HOME directory
 ############################################
 export NWROOT=/lfs/h2/emc/vpppg/noscrub/yali.mao/git
-export HOMEwafs=${HOMEwafs:-${NWROOT}/WAFS.fork}
+export HOMEwafs=${HOMEwafs:-${NWROOT}/wafs.fork}
 
 ############################################
 # Loading module

--- a/dev/driver/run_JWAFS_GRIB2_1P25
+++ b/dev/driver/run_JWAFS_GRIB2_1P25
@@ -20,7 +20,7 @@ set -x
 # Set up the HOME directory
 ############################################
 export NWROOT=/lfs/h2/emc/vpppg/noscrub/yali.mao/git
-export HOMEwafs=${HOMEwafs:-${NWROOT}/WAFS.fork}
+export HOMEwafs=${HOMEwafs:-${NWROOT}/wafs.fork}
 
 ############################################
 # Loading module
@@ -82,6 +82,7 @@ export KEEPDATA=YES
 
 export COMROOT=/lfs/h2/emc/ptmp/$USER/wafs_dwn/$envir/com
 
+COMPATHgfs=/lfs/h2/emc/vpppg/noscrub/yali.mao/gfsv17data/prod/com/gfs
 export COMPATH=${COMPATHgfs:-/lfs/h1/ops/prod/com/gfs}:/lfs/h2/emc/ptmp/yali.mao/wafs_dwn/prod/com/wafs
 
 export DATA=/lfs/h2/emc/ptmp/$USER/working_wafs/grib2_1p25.$jobid

--- a/dev/driver/run_JWAFS_UPP
+++ b/dev/driver/run_JWAFS_UPP
@@ -92,8 +92,8 @@ export KEEPDATA=YES
 
 export COMROOT=/lfs/h2/emc/ptmp/$USER/wafs_dwn/$envir/com
 
+COMPATHgfs=/lfs/h2/emc/vpppg/noscrub/yali.mao/gfsv17data/prod/com/gfs
 export COMPATH=${COMPATHgfs:-/lfs/h1/ops/prod/com/gfs}
-export COMINgfs="/lfs/h2/emc/vpppg/noscrub/yali.mao/gfsv17data/gfs.$PDY/$cyc/model/atmos/history"
 
 DATAroot=/lfs/h2/emc/ptmp/$USER/working_wafs
 

--- a/dev/driver/run_JWAFS_UPP
+++ b/dev/driver/run_JWAFS_UPP
@@ -5,9 +5,8 @@
 #PBS -o /lfs/h2/emc/ptmp/yali.mao/working_wafs/log.wafs_upp
 #PBS -N wafs_upp
 #PBS -l debug=true
-#PBS -l walltime=00:15:00
-#PBS -l select=1:mpiprocs=126:ompthreads=1:ncpus=126
-#PBS -l place=vscatter:exclhost
+#PBS -l walltime=00:30:00
+#PBS -l place=vscatter:exclhost,select=6:ompthreads=1:ncpus=25:mem=480GB
 #PBS -q debug
 #PBS -A GFS-DEV
 ##PBS -V
@@ -16,7 +15,7 @@ set -x
 
 # specify computation resource
 export MP_LABELIO=yes
-export MPIRUN='mpiexec -l -n 126 -ppn 126 --cpu-bind depth --depth 1'
+export MPIRUN='mpiexec -l -n 150 -ppn 25'
 
 echo "starting time $PBS_JOBNAME"
 
@@ -24,7 +23,7 @@ echo "starting time $PBS_JOBNAME"
 # Set up the HOME directory
 ############################################
 export NWROOT=/lfs/h2/emc/vpppg/noscrub/yali.mao/git
-export HOMEwafs=${HOMEwafs:-${NWROOT}/WAFS.fork}
+export HOMEwafs=${HOMEwafs:-${NWROOT}/wafs.fork}
 
 # specify user's own post working directory for testing
 export EXECwafs=$HOMEwafs/exec
@@ -94,6 +93,7 @@ export KEEPDATA=YES
 export COMROOT=/lfs/h2/emc/ptmp/$USER/wafs_dwn/$envir/com
 
 export COMPATH=${COMPATHgfs:-/lfs/h1/ops/prod/com/gfs}
+export COMINgfs="/lfs/h2/emc/vpppg/noscrub/yali.mao/gfsv17data/gfs.$PDY/$cyc/model/atmos/history"
 
 DATAroot=/lfs/h2/emc/ptmp/$USER/working_wafs
 

--- a/dev/driver/submit.run_JWAFS.sh
+++ b/dev/driver/submit.run_JWAFS.sh
@@ -18,6 +18,7 @@ cp "${DIR_ROOT}/dev/driver/${jobcard}" .
 if [ $job = 'upp' ]; then
   FHOURS="anl 000 006 007 008 009 010 011 012 013 014 015 016 017 018 019 020 021 022 023 024 \
   027 030 033 036 039 042 045 048 054 060 066 072 078 084 090 096 102 108 114 120"
+  FHOURS="024"
 elif [ $job = 'gcip' ]; then
   FHOURS="000 003"
 elif [ $job = 'grib2_0p25' ]; then
@@ -27,10 +28,13 @@ elif [ $job = 'grib2_0p25' ]; then
   else #39
     export FHOURS=${FHOURS:-"6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 27 30 33 36 39 42 45 48 54 60 66 72 78 84 90 96 102 108 114 120"}
   fi
+  export FHOURS="024"
 elif [ $job = 'grib2_1p25' ]; then
   export FHOURS=${FHOURS:-"00 06 09 12 15 18 21 24 27 30 33 36 42 48 54 60 66 72"}
+  export FHOURS="024"
 elif [ $job = 'grib' ]; then
   export FHOURS=${FHOURS:-"06 12 18 24 30 36 42 48 54 60 66 72"}
+  export FHOURS="24"
 elif [ $job = 'grib2_0p25_blending' ]; then
   sed -e "s|log.wafs_$job|log.wafs_$job|g" \
   -e "s|HOMEwafs=.*|HOMEwafs=$DIR_ROOT|g" \

--- a/jobs/JWAFS_GCIP
+++ b/jobs/JWAFS_GCIP
@@ -24,6 +24,7 @@ setpdy.sh
 # SEND to COM, DBN, etc
 ####################################
 export SENDCOM=${SENDCOM:-"YES"}
+export SENDDBN=${SENDDBN:-"YES"}
 
 ####################################
 # Specify NET and RUN Name and model

--- a/jobs/JWAFS_GCIP
+++ b/jobs/JWAFS_GCIP
@@ -35,7 +35,7 @@ export RUN=${RUN:-wafs}
 ##############################################
 # Define COM directories
 ##############################################
-export COMINgfs=${COMINgfs:-$(compath.py "${envir}/gfs/${gfs_ver}")"/gfs.${PDY}/${cyc}/atmos"}
+export COMINgfs=${COMINgfs:-$(compath.py "${envir}/gfs/${gfs_ver}")"/gfs.${PDY}/${cyc}/model/atmos/master"}
 export DCOMROOTsat=${DCOMROOTsat:-"$DCOMROOT"}
 export COMINsat=${COMINsat:-"${DCOMROOTsat}/${PDY}/mcidas"}
 export COMINradar=${COMINradar:-$(compath.py "${envir}/radarl2/${radarl2_ver}")"/radar.${PDY}"}

--- a/jobs/JWAFS_GRIB
+++ b/jobs/JWAFS_GRIB
@@ -35,7 +35,7 @@ export RUN=${RUN:-wafs}
 ##############################################
 # Define COM directories
 ##############################################
-export COMINgfs=${COMINgfs:-$(compath.py "${envir}/gfs/${gfs_ver}")"/gfs.${PDY}/${cyc}/atmos"}
+export COMINgfs=${COMINgfs:-$(compath.py "${envir}/gfs/${gfs_ver}")"/gfs.${PDY}/${cyc}/model/atmos/master"}
 export COMOUT=${COMOUT:-$(compath.py -o "${NET}/${wafs_ver}")"/${RUN}.${PDY}/${cyc}/grib"}
 export COMOUTwmo=${COMOUTwmo:-"${COMOUT}/wmo"}
 mkdir -p "${COMOUT}" "${COMOUTwmo}"

--- a/jobs/JWAFS_GRIB2_0P25
+++ b/jobs/JWAFS_GRIB2_0P25
@@ -36,7 +36,7 @@ export RUN=${RUN:-wafs}
 ##############################################
 # Define COM directories
 ##############################################
-export COMINgfs=${COMINgfs:-$(compath.py "${envir}/gfs/${gfs_ver}")"/gfs.${PDY}/${cyc}/atmos"}
+export COMINgfs=${COMINgfs:-$(compath.py "${envir}/gfs/${gfs_ver}")"/gfs.${PDY}/${cyc}/model/atmos/master"}
 export COMIN=${COMIN:-$(compath.py "${envir}/${NET}/${wafs_ver}")"/${RUN}.${PDY}/${cyc}/upp"}
 export COMOUT=${COMOUT:-$(compath.py -o "${NET}/${wafs_ver}")"/${RUN}.${PDY}/${cyc}/grib2/0p25"}
 mkdir -p "${COMOUT}"

--- a/jobs/JWAFS_GRIB2_1P25
+++ b/jobs/JWAFS_GRIB2_1P25
@@ -37,7 +37,7 @@ export RUN=${RUN:-wafs}
 ##############################################
 # Define COM directories
 ##############################################
-export COMINgfs=${COMINgfs:-$(compath.py "${envir}/gfs/${gfs_ver}")"/gfs.${PDY}/${cyc}/atmos"}
+export COMINgfs=${COMINgfs:-$(compath.py "${envir}/gfs/${gfs_ver}")"/gfs.${PDY}/${cyc}/model/atmos/master"}
 export COMIN=${COMIN:-$(compath.py "${envir}/${NET}/${wafs_ver}")"/${RUN}.${PDY}/${cyc}/upp"}
 export COMOUT=${COMOUT:-$(compath.py -o "${NET}/${wafs_ver}")"/${RUN}.${PDY}/${cyc}/grib2/1p25"}
 export COMOUTwmo=${COMOUTwmo:-"${COMOUT}/wmo"}

--- a/jobs/JWAFS_UPP
+++ b/jobs/JWAFS_UPP
@@ -35,7 +35,7 @@ export RUN=${RUN:-wafs}
 ##############################################
 # Define COM directories
 ##############################################
-export COMINgfs=${COMINgfs:-$(compath.py "${envir}/gfs/${gfs_ver}")"/gfs.${PDY}/${cyc}/atmos"}
+export COMINgfs=${COMINgfs:-$(compath.py "${envir}/gfs/${gfs_ver}")"/gfs.${PDY}/${cyc}/model/atmos/history"}
 export COMOUT=${COMOUT:-$(compath.py -o "${NET}/${wafs_ver}")"/${RUN}.${PDY}/${cyc}/upp"}
 mkdir -p "${COMOUT}"
 

--- a/scripts/exwafs_gcip.sh
+++ b/scripts/exwafs_gcip.sh
@@ -85,7 +85,7 @@ done
 # Copy GFS master file and prepare modelFile
 cpreq "${COMINgfs}/gfs.t${cyc}z.master.grb2f${fhr}" ./gfs_master.grib2
 modelFile="modelfile.grb"
-${WGRIB2} "gfs_master.grib2" | grep -E ":HGT:|:VVEL:|:CLWMR:|:TMP:|:SPFH:|:RWMR:|:SNMR:|:GRLE:|:ICMR:|:RH:" | grep -E "00 mb:|25 mb:|50 mb:|75 mb:|:HGT:surface" | ${WGRIB2} -i "gfs_master.grib2" -grib "${modelFile}"
+${WGRIB2} "gfs_master.grib2" | grep -E ":HGT:|:VVEL:|:CLMR:|:TMP:|:SPFH:|:RWMR:|:SNMR:|:GRLE:|:ICMR:|:RH:" | grep -E "00 mb:|25 mb:|50 mb:|75 mb:|:HGT:surface" | ${WGRIB2} -i "gfs_master.grib2" -grib "${modelFile}"
 
 # Composite gcip command options
 configFile="gcip.config"

--- a/scripts/exwafs_gcip.sh
+++ b/scripts/exwafs_gcip.sh
@@ -147,3 +147,8 @@ fi
 if [[ "${SENDCOM}" == "YES" ]]; then
 	cpfs "${outputfile}" "${COMOUT}/${outputfile}"
 fi
+
+# Alert via DBN
+if [[ "${SENDDBN}" == "YES" ]]; then
+    "${DBNROOT}/bin/dbn_alert" MODEL WAFS_GCIP_GB2 "${job}" "${COMOUT}/${outputfile}"
+fi

--- a/scripts/exwafs_upp.sh
+++ b/scripts/exwafs_upp.sh
@@ -17,12 +17,13 @@ set -x
 POSTGRB2TBL=${POSTGRB2TBL:-"${g2tmpl_ROOT}/share/params_grib2_tbl_new"}
 MPIRUN=${MPIRUN:-"mpiexec -l -n 126 -ppn 126 --cpu-bind depth --depth 1"}
 
+nampgb_suffix="popascal=.true., numx=1"
 if [[ "${fhr}" == "anl" ]]; then # Analysis
 
     VDATE="${PDY}${cyc}"
     ATMINP="${COMINgfs}/gfs.t${cyc}z.atmanl.nc"
     FLXINP="${COMINgfs}/gfs.t${cyc}z.sfcanl.nc"
-    PostFlatFile="${PARMwafs}/upp/postxconfig-NT-GFS-WAFS-ANL.txt"
+    PostFlatFile="${PARMwafs}/upp/postxconfig-NT-gfs-wafs-anl.txt"
 
 else # Forecast
 
@@ -31,9 +32,11 @@ else # Forecast
     FLXINP="${COMINgfs}/gfs.t${cyc}z.sfcf${fhr}.nc"
     ifhr="$((10#${fhr}))"
     if ((ifhr <= 48)); then
-        PostFlatFile="${PARMwafs}/upp/postxconfig-NT-GFS-WAFS.txt"
+        PostFlatFile="${PARMwafs}/upp/postxconfig-NT-gfs-wafs.txt"
+	
+	nampgb_suffix="gtg_on=.true., $nampgb_suffix"
     else
-        PostFlatFile="${PARMwafs}/upp/postxconfig-NT-GFS-WAFS-EXT.txt"
+        PostFlatFile="${PARMwafs}/upp/postxconfig-NT-gfs-wafs-ext.txt"
     fi
 
 fi
@@ -45,26 +48,28 @@ cpreq "${ATMINP}" ./atmfile
 cpreq "${FLXINP}" ./flxfile
 cpreq "${POSTGRB2TBL}" .
 cpreq "${PostFlatFile}" ./postxconfig-NT.txt
-cpreq "${PARMwafs}/upp/nam_micro_lookup.dat" ./eta_micro_lookup.dat
 if [[ "${fhr}" != "anl" ]]; then
-    cpreq "${PARMwafs}/upp/gtg.config.gfs" gtg.config
-    cpreq "${PARMwafs}/upp/gtg_imprintings.txt" gtg_imprintings.txt
+    cpreq "${PARMwafs}/upp/gtg.input.gfs" gtg.input.gfs
+    cpreq "${PARMwafs}/upp/gtg.config.gfs" gtg.config.gfs
+    cpreq "${PARMwafs}/upp/imprintings.gtg_gfs.txt" imprintings.gtg_gfs.txt
 fi
 
 # Create the itag file
 rm -f itag
 cat >itag <<EOF
-atmfile
-netcdfpara
-grib2
-${VDATE:0:4}-${VDATE:4:2}-${VDATE:6:2}_${VDATE:8:2}:00:00
-GFS
-flxfile
-
-&nampgb
+&model_inputs
+fileName="atmfile"
+IOFORM="netcdf"
+grib="grib2"
+DateStr="${VDATE:0:4}-${VDATE:4:2}-${VDATE:6:2}_${VDATE:8:2}:00:00"
+MODELNAME="GFS"
+SUBMODELNAME="GFS"
+fileNameFlux="flxfile"
+/
+&NAMPGB
   kpo=60,
   po=97720.,94210.,90810.,87510.,84310.,81200.,78190.,75260.,72430.,69680.,67020.,64440.,61940.,59520.,57180.,54920.,52720.,50600.,48550.,46560.,44650.,42790.,41000.,39270.,37600.,35990.,34430.,32930.,31490.,30090.,28740.,27450.,26200.,25000.,23840.,22730.,21660.,20650.,19680.,18750.,17870.,17040.,16240.,15470.,14750.,14060.,13400.,12770.,12170.,11600.,11050.,10530.,10040.,9570.,9120.,8700.,8280.,7900.,7520.,7170.,
-  popascal=.true.,
+  $nampgb_suffix
 /
 EOF
 cat itag

--- a/sorc/build_upp.sh
+++ b/sorc/build_upp.sh
@@ -10,35 +10,12 @@ if [[ ! -d "${DIR_ROOT}/exec" ]]; then
   mkdir -p "${DIR_ROOT}/exec"
 fi
 
-# upp_v8.3.0:
-cd "${DIR_ROOT}/sorc/wafs_upp.fd"
-
-# copy WAFS specific UPP parm/ files to the main vertical structure
-mkdir -p "${DIR_ROOT}/parm/upp"
-upp_parm_files=(nam_micro_lookup.dat \
-                postcntrl_gfs_wafs_anl.xml \
-                postcntrl_gfs_wafs_ext.xml \
-                postcntrl_gfs_wafs.xml \
-                postxconfig-NT-GFS-WAFS-ANL.txt \
-                postxconfig-NT-GFS-WAFS-EXT.txt \
-                postxconfig-NT-GFS-WAFS.txt \
-                gtg_imprintings.txt )
-for upp_parm_file in "${upp_parm_files[@]}"; do
-  rm -f "${DIR_ROOT}/parm/upp/${upp_parm_file}"
-  cp "parm/${upp_parm_file}" "${DIR_ROOT}/parm/upp/${upp_parm_file}"
-done
-rm -f "${DIR_ROOT}/parm/upp/gtg.config.gfs"
-cp "sorc/post_gtg.fd/gtg.config.gfs" "${DIR_ROOT}/parm/upp/gtg.config.gfs"
-
-# copy GTG code to UPP
-cp -f sorc/post_gtg.fd/*f90 sorc/ncep_post.fd/.
-
 # Build upp executable file
-cd "${DIR_ROOT}/sorc/wafs_upp.fd/sorc"
-./build_ncep_post.sh
+cd "${DIR_ROOT}/sorc/wafs_upp.fd/tests"
+./compile_upp.sh -g
 
 # Copy upp to WAFS/exec
 rm -rf "${DIR_ROOT}/exec/wafs_upp.x"
-cp "${DIR_ROOT}/sorc/wafs_upp.fd/exec/ncep_post" "${DIR_ROOT}/exec/wafs_upp.x"
+cp "${DIR_ROOT}/sorc/wafs_upp.fd/exec/upp.x" "${DIR_ROOT}/exec/wafs_upp.x"
 
 exit

--- a/sorc/checkout_upp.sh
+++ b/sorc/checkout_upp.sh
@@ -8,4 +8,29 @@ readonly DIR_ROOT=$(cd "$(dirname "$(readlink -f -n "${BASH_SOURCE[0]}" )" )/.."
 cd "${DIR_ROOT}"
 
 # Checkout upp and gtg code
-git submodule update --init --recursive
+git -c submodule."post_gtg.fd".update=checkout submodule update --init --recursive
+
+# upp:
+cd "${DIR_ROOT}/sorc/wafs_upp.fd"
+
+# copy WAFS specific UPP parm/ files to the main vertical structure
+mkdir -p "${DIR_ROOT}/parm/upp"
+upp_parm_files=(postcntrl_gfs_wafs_anl.xml \
+                postcntrl_gfs_wafs_ext.xml \
+                postcntrl_gfs_wafs.xml \
+                postxconfig-NT-gfs-wafs-anl.txt \
+                postxconfig-NT-gfs-wafs-ext.txt \
+                postxconfig-NT-gfs-wafs.txt)
+for upp_parm_file in "${upp_parm_files[@]}"; do
+  rm -f "${DIR_ROOT}/parm/upp/${upp_parm_file}"
+  cp "parm/gfs/${upp_parm_file}" "${DIR_ROOT}/parm/upp/${upp_parm_file}"
+done
+gtg_parm_files=(gtg.config.gfs \
+		gtg.input.gfs \
+                imprintings.gtg_gfs.txt)
+for gtg_parm_file in "${gtg_parm_files[@]}"; do
+    rm -f "${DIR_ROOT}/parm/upp/${gtg_parm_file}"
+    cp "sorc/ncep_post.fd/post_gtg.fd/${gtg_parm_file}" "${DIR_ROOT}/parm/upp/${gtg_parm_file}"
+done
+
+exit

--- a/sorc/checkout_upp.sh
+++ b/sorc/checkout_upp.sh
@@ -23,7 +23,7 @@ upp_parm_files=(postcntrl_gfs_wafs_anl.xml \
                 postxconfig-NT-gfs-wafs.txt)
 for upp_parm_file in "${upp_parm_files[@]}"; do
   rm -f "${DIR_ROOT}/parm/upp/${upp_parm_file}"
-  cp "parm/gfs/${upp_parm_file}" "${DIR_ROOT}/parm/upp/${upp_parm_file}"
+  cp "parm/wafs/${upp_parm_file}" "${DIR_ROOT}/parm/upp/${upp_parm_file}"
 done
 gtg_parm_files=(gtg.config.gfs \
 		gtg.input.gfs \

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -21,5 +21,5 @@ export netcdf_ver=4.7.4
 export g2tmpl_ver=1.13.0
 export prod_util_ver=2.0.14
 export grib_util_ver=1.2.3
-export wgrib2_ver=2.0.7
+export wgrib2_ver=2.0.8
 

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,4 +1,4 @@
-export wafs_ver=v7.0.1
+export wafs_ver=v7.0.2
 
 export gfs_ver=v16.3
 export radarl2_ver=v1.2

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,6 +1,6 @@
 export wafs_ver=v7.0.2
 
-export gfs_ver=v16.3
+export gfs_ver=v17.0
 export radarl2_ver=v1.2
 export bufr_dump_ver=1.1.2
 export util_shared_ver=1.4.0


### PR DESCRIPTION
A series of updates:

1. Update UPP version with GTG4 version update. In the UPP version update, cherry pick the change of adding additional levels for WAFS icing and turbulence which was made for GFSv16.3.
2. Update scripts for UPP parm folder restructure
3. Add dbn_alert of GCIP
4. Update scripts for GFS output restructure
5. Switch CLWMR to CLMR