### PR TITLE
Add compatibility for future bacio upgrade to 2.5+

### DIFF
--- a/sorc/CMakeLists.txt
+++ b/sorc/CMakeLists.txt
@@ -24,6 +24,11 @@ endif()
 
 # Find packages.
 find_package(bacio REQUIRED)
+if(bacio_VERSION LESS 2.5.0)
+  add_library(bacio::bacio ALIAS bacio::bacio_4)
+else()
+  add_library(bacio::bacio_4 ALIAS bacio::bacio)
+endif()
 find_package(w3emc REQUIRED)
 find_package(sp REQUIRED)
 find_package(ip REQUIRED)

--- a/sorc/wafs_blending_0p25.fd/CMakeLists.txt
+++ b/sorc/wafs_blending_0p25.fd/CMakeLists.txt
@@ -7,7 +7,7 @@ add_executable(${exe_name} ${fortran_src})
 target_link_libraries(
   ${exe_name}
   g2::g2_4
-  bacio::bacio_4
+  bacio::bacio
   w3emc::w3emc_4
 )
 

--- a/sorc/wafs_cnvgrib2.fd/CMakeLists.txt
+++ b/sorc/wafs_cnvgrib2.fd/CMakeLists.txt
@@ -18,7 +18,7 @@ add_executable(${exe_name} ${fortran_src})
 target_link_libraries(
   ${exe_name}
   g2::g2_4
-  bacio::bacio_4
+  bacio::bacio
   w3emc::w3emc_4
 )
 

--- a/sorc/wafs_gcip.fd/CMakeLists.txt
+++ b/sorc/wafs_gcip.fd/CMakeLists.txt
@@ -30,7 +30,7 @@ target_link_libraries(
   g2::g2_4
   ip::ip_4
   sp::sp_4
-  bacio::bacio_4
+  bacio::bacio
   w3emc::w3emc_4
   bufr::bufr_4
 )


### PR DESCRIPTION
Add compatibility for future bacio upgrade to 2.5+

One exception is wafs_makewafs.fd which uses bacio_8 and doesn't work with bacio 2.5+
wafs_makewafs.fd is used by grib1 products. When grib1 products retire, there will be
no issue to do the upgrade
