### PR TITLE
Fix bugzilla 1712 - False alarm emails for missing GLOBCOMPVIS files

### DIFF
--- a/parm/wafs/wafs_gcip_gfs.cfg
+++ b/parm/wafs/wafs_gcip_gfs.cfg
@@ -218,8 +218,8 @@ nfiner = 2
 # https://www.ssec.wisc.edu/mcidas/doc/users_guide.html
 # https://www.ssec.wisc.edu/mcidas/doc/users_guide/current/app_c-1.html or https://www.ssec.wisc.edu/mcidas/doc/users_guide/2018.1/app_c-1.html
 # https://www.eumetsat.int/website/home/Satellites/CurrentSatellites/Meteosat/index.html
-#                  METEOSAT-9(MSG2) METEOSAT-10(MSG3) METEOSAT-11(MSG4) HIMAWARI-8  HIMAWARI-9   GOES-E 16  GOES-W 17   GOES-18
-satellite_source = 52 45.5,         53 0.0,           98 9.5,           86 140.7,   31 140.7,     186 -75.2, 188 -105,   190 -137.2
+#                  METEOSAT-9(MSG2) METEOSAT-10(MSG3) METEOSAT-11(MSG4) HIMAWARI-8  HIMAWARI-9   GOES-E 16  GOES-W 17   GOES-18     GOES-19
+satellite_source = 52 45.5,         53 0.0,           98 9.5,           86 140.7,   31 140.7,     186 -75.2, 188 -105,   190 -137.2, 192 -75.2
 # Fortran code has taken care of the well known SS numbers
 
 # for SatDerive

--- a/scripts/exwafs_gcip.sh
+++ b/scripts/exwafs_gcip.sh
@@ -47,7 +47,7 @@ satFiles=""
 channels="VIS SIR LIR SSR"
 # If one channel is missing, satFiles will be empty
 for channel in ${channels}; do
-	satFile="$(find ${COMINsat} -name GLOBCOMP${channel}*${PDY}${vhour}*area)"
+	satFile="$(find ${COMINsat} -name GLOBCOMP${channel}*_s${PDY}${vhour}*area)"
 	if [[ "${COMINsat}" == *ftp:* ]]; then
 		curl -O "${COMINsat}/${satFile}"
 	else


### PR DESCRIPTION
Fix bugzilla 1712 - False alarm emails for missing GLOBCOMPVIS files

Add GOES-19 (sensor #192) to the satellite sensor list